### PR TITLE
Let outgroup members wear goggles

### DIFF
--- a/src/sprites/entities/character.py
+++ b/src/sprites/entities/character.py
@@ -162,14 +162,6 @@ class Character(Entity, ABC):
                 necklace_frame.set_alpha(self.image_alpha)
                 blit_list.append((necklace_frame, rect))
 
-        # Render the goggles
-        if self.has_goggles:
-            goggles_state = EntityState(f"goggles_{self.state.value}")
-            goggles_ani = self.assets[goggles_state][self.facing_direction]
-            goggles_frame = goggles_ani.get_frame(self.frame_index)
-            goggles_frame.set_alpha(self.image_alpha)
-            blit_list.append((goggles_frame, rect))
-
         # Render the hat/horn (depending on the group)
         if is_in_ingroup:
             if self.has_hat:
@@ -204,6 +196,14 @@ class Character(Entity, ABC):
                 horn_frame = horn_ani.get_frame(self.frame_index)
                 horn_frame.set_alpha(self.image_alpha)
                 blit_list.append((horn_frame, rect))
+
+        # Render the goggles
+        if self.has_goggles:
+            goggles_state = EntityState(f"goggles_{self.state.value}")
+            goggles_ani = self.assets[goggles_state][self.facing_direction]
+            goggles_frame = goggles_ani.get_frame(self.frame_index)
+            goggles_frame.set_alpha(self.image_alpha)
+            blit_list.append((goggles_frame, rect))
 
         display_surface.fblits(blit_list)
 


### PR DESCRIPTION
## Summary

This PR lets outgroup NPCs and player characters wear goggles without render artifacts.

## Media
![image](https://github.com/user-attachments/assets/e070bc44-1cab-4ae8-aaa7-fc09ae3d3a51)

## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.
