### PR TITLE
Refer to the Red Hats when presenting the income of the non-player group if the player is a Hornling

### DIFF
--- a/data/translations/de.json
+++ b/data/translations/de.json
@@ -68,6 +68,7 @@
     "whole_finish": "Das Spiel ist abgeschlossen! Bitte \u00f6ffnen Sie jetzt den Fragebogen aus der heutigen E-Mail. Sie k\u00f6nnen das Fenster jetzt schliessen. Besitz der Roth\u00fcte am Ende: ${money} und:",
     "next_round": "Weiter in die n\u00e4chste Runde",
     "outgroup_income_round_end": "Die Hornlinge haben letzte Runde {money}$ verdient.",
+    "ingroup_income_round_end": "Die Roth\u00fcte haben letzte Runde {money}$ verdient.",
     "task": "Aufgabe",
     "confirm": "Best\u00e4tigen",
     "share_items": "Wem m\u00f6chtest du wie viel geben?",

--- a/data/translations/de.txt
+++ b/data/translations/de.txt
@@ -87,6 +87,7 @@ temp_finish@@Für heute ist das Spiel beendet. Morgen geht es weiter - wir schic
 whole_finish@@Das Spiel ist abgeschlossen! Bitte öffnen Sie jetzt den Fragebogen aus der heutigen E-Mail. Sie können das Fenster jetzt schliessen. Besitz der Rothüte am Ende: ${money} und:
 next_round@@Weiter in die nächste Runde
 outgroup_income_round_end@@Die Hornlinge haben letzte Runde {money}$ verdient.
+ingroup_income_round_end@@Die Rothüte haben letzte Runde {money}$ verdient.
 
 # task (items allocation) menu
 

--- a/data/translations/en.json
+++ b/data/translations/en.json
@@ -68,6 +68,7 @@
     "whole_finish": "Thanks for playing, you are done with the whole game. At the end, you had ${money}, and:",
     "next_round": "continue to next round",
     "outgroup_income_round_end": "The Hornlings earned ${money} in the last round.",
+    "ingroup_income_round_end": "The Red Hats earned ${money} in the last round.",
     "task": "Task",
     "confirm": "Confirm",
     "share_items": "Distribute them",

--- a/data/translations/en.txt
+++ b/data/translations/en.txt
@@ -86,6 +86,7 @@ temp_finish@@Thanks for playing, you are done for the day. You currently have ${
 whole_finish@@Thanks for playing, you are done with the whole game. At the end, you had ${money}, and:
 next_round@@continue to next round
 outgroup_income_round_end@@The Hornlings earned ${money} in the last round.
+ingroup_income_round_end@@The Red Hats earned ${money} in the last round.
 
 # task (items allocation) menu
 

--- a/main.py
+++ b/main.py
@@ -134,12 +134,12 @@ def _get_alloc_text(alloc_id: str):
     return txt_to_add
 
 
-def _get_outgroup_income(money: str):
+def _get_outgroup_income(money: str, in_outgrp: bool = False):
     actual_money = money
     if GAME_LANGUAGE == "en":
         # English currency formatting works like the German one, but with commas instead of colons.
         actual_money = money.replace(".", ",")
-    return get_translated_msg("outgroup_income_round_end").format(money=actual_money)
+    return get_translated_msg(f"{'in' if in_outgrp else 'out'}group_income_round_end").format(money=actual_money)
 
 
 class Game:
@@ -932,7 +932,8 @@ class Game:
                         self._notify(message, "questionnaire")
                     elif self._can_notify_outgroup_money_income:
                         message = _get_outgroup_income(
-                            self.round_config["notify_round_end_outgroup_text"]
+                            self.round_config["notify_round_end_outgroup_text"],
+                            self.player.in_outgroup
                         )
                         self._notify(message, "round_end_outgroup")
                     elif self._can_start_self_assessment_sequence:

--- a/main.py
+++ b/main.py
@@ -139,7 +139,9 @@ def _get_outgroup_income(money: str, in_outgrp: bool = False):
     if GAME_LANGUAGE == "en":
         # English currency formatting works like the German one, but with commas instead of colons.
         actual_money = money.replace(".", ",")
-    return get_translated_msg(f"{'in' if in_outgrp else 'out'}group_income_round_end").format(money=actual_money)
+    return get_translated_msg(
+        f"{'in' if in_outgrp else 'out'}group_income_round_end"
+    ).format(money=actual_money)
 
 
 class Game:
@@ -933,7 +935,7 @@ class Game:
                     elif self._can_notify_outgroup_money_income:
                         message = _get_outgroup_income(
                             self.round_config["notify_round_end_outgroup_text"],
-                            self.player.in_outgroup
+                            self.player.in_outgroup,
                         )
                         self._notify(message, "round_end_outgroup")
                     elif self._can_start_self_assessment_sequence:


### PR DESCRIPTION
## Summary

This PR fixes the outgroup income notification as described in issue #40.

If the player joined the Hornlings, the money notification will refer to the Red Hats instead of the Hornlings, since the player isn't a Red Hat anymore.

## Media
(Debug conditions, please ignore the player's state)
![image](https://github.com/user-attachments/assets/02a82a68-d04f-4759-a1fe-7e5570bfc1fe)


## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.
