### PR TITLE
Ended fix, issue #60

### DIFF
--- a/src/screens/menu_round_end.py
+++ b/src/screens/menu_round_end.py
@@ -33,7 +33,9 @@ class RoundMenu(GeneralMenu):
             self.img = pygame.Surface(rect.size, flags=pygame.SRCALPHA)
             self.img.fill(pygame.Color(0, 0, 0, 0))
             FBLITTER.set_current_surf(self.img)
-            FBLITTER.draw_rect("azure3", pygame.Rect(0, 0, rect.width, rect.height), 0, 4)
+            FBLITTER.draw_rect(
+                "azure3", pygame.Rect(0, 0, rect.width, rect.height), 0, 4
+            )
             # pygame.draw.rect(self.img, "azure3", (0, 0, rect.width, rect.height), 0, 4)
 
             # crop icon

--- a/src/screens/social_identity_assessment.py
+++ b/src/screens/social_identity_assessment.py
@@ -240,7 +240,7 @@ class SocialIdentityAssessmentMenu(AbstractMenu):
                 text_surf = self.font.render(
                     get_translated_msg(text_key), False, "Black"
                 )
-                half_width_of_text = text_surf.width / 2
+                half_width_of_text = text_surf.get_frect().width / 2
                 current_button_bottom_left = current_button.rect.midbottom
                 FBLITTER.schedule_blit(
                     text_surf,


### PR DESCRIPTION
This PR completes the correction of error #60.
As it was described in comments, line 243 in the file `social_identity_assessment.py` is changed to

`half_width_of_text = text_surf.get_frect().width / 2`

It's necessary for the next tests in a browser.

In addition, the formatting of the menu_round_end.py file has been improved, as agreed with @sloukit.

- [x]  I have tested this change locally and it works as expected.
- [x]  I have made sure that the code follows the formatting and style guidelines of the project.