### PR TITLE
Removed a redundant check on a variable.

### DIFF
--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -1169,8 +1169,6 @@ class Level:
 
             self.activate_music()  # Activating the old music
 
-            if self.volcano_event:
-                self.intro_shown.pop(Map.VOLCANO)
             self.current_map = self.prev_map
             self.prev_map = Map.VOLCANO
             self.map_transition.reset = partial(self.switch_to_map, self.current_map)


### PR DESCRIPTION
The check popped out an index from a array that had nothing it, and in all of my testing never have a value in it. 

Addresses #84

