### PR TITLE
Fix #83, Only In group Shows Sickness

### DIFF
--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -286,4 +286,4 @@ class NPC(NPCBase):
         if self.is_dead:
             return
 
-        super().draw(display_surface, rect, camera)
+        super().draw(display_surface, rect, camera, self.is_sick)

--- a/src/sprites/entities/character.py
+++ b/src/sprites/entities/character.py
@@ -17,6 +17,7 @@ from src.enums import (
 from src.fblitter import FBLITTER
 from src.sprites.entities.entity import Entity
 from src.sprites.setup import EntityAsset
+from src.sprites.entities.sick_color_effect import apply_sick_color_effect
 
 
 class Character(Entity, ABC):
@@ -151,12 +152,14 @@ class Character(Entity, ABC):
     def in_outgroup(self):
         return self.study_group == StudyGroup.OUTGROUP
 
-    def draw(self, display_surface: pygame.Surface, rect: pygame.Rect, camera):
-        # super().draw(display_surface, rect, camera)
+    def draw(self, display_surface: pygame.Surface, rect: pygame.Rect, camera, sick):
+        # See src.sprites.entities.sick_color_effect and .player for more info on sickness
+
+        # super().draw(display_surface, rect, camera, sick)
         # blit_list = []
 
         # Render the necklace if the character has it and is in the ingroup
-        is_in_ingroup = self.study_group == StudyGroup.INGROUP
+        is_in_ingroup = not self.in_outgroup
 
         if is_in_ingroup:
             super().draw(display_surface, rect, camera)
@@ -176,29 +179,47 @@ class Character(Entity, ABC):
                 # hat_frame.set_alpha(self.image_alpha)  # hat is always visible, looks silly otherwise
                 FBLITTER.schedule_blit(hat_frame, rect)
 
-        elif self.study_group == StudyGroup.OUTGROUP:
+        elif not is_in_ingroup:
             if self.has_outgroup_skin:
                 skin_state = EntityState(f"outgroup_{self.state.value}")
                 skin_ani = self.assets[skin_state][self.facing_direction]
                 skin_frame = skin_ani.get_frame(self.frame_index)
+
+                # sickness fix here
+                if sick:
+                    skin_frame = apply_sick_color_effect(skin_frame)
+
                 skin_frame.set_alpha(self.image_alpha)
                 FBLITTER.schedule_blit(skin_frame, rect)
             else:
-                # if transition to outgroup has not finished, drew the ingroup body
+                # if transition to outgroup has not finished, draw the ingroup body
                 self.image.set_alpha(self.image_alpha)
+
+                original_image = self.image
+                if sick:
+                    self.image = apply_sick_color_effect(self.image)
+
                 super().draw(display_surface, rect, camera)
+                self.image = original_image
 
                 if self.has_hat:
                     hat_state = EntityState(f"hat_{self.state.value}")
                     hat_ani = self.assets[hat_state][self.facing_direction]
                     hat_frame = hat_ani.get_frame(self.frame_index)
+
+                    # seems not needed
+                    # if sick:
+                    #     hat_frame = apply_sick_color_effect(hat_frame)
+
                     hat_frame.set_alpha(self.image_alpha)
                     FBLITTER.schedule_blit(hat_frame, rect)
 
             if self.has_horn:
+                # no sickness setup required.. we've already hit a previous sick check
                 horn_state = EntityState(f"horn_{self.state.value}")
                 horn_ani = self.assets[horn_state][self.facing_direction]
                 horn_frame = horn_ani.get_frame(self.frame_index)
+
                 horn_frame.set_alpha(self.image_alpha)
                 FBLITTER.schedule_blit(horn_frame, rect)
 
@@ -208,6 +229,11 @@ class Character(Entity, ABC):
             goggles_ani = self.assets[goggles_state][self.facing_direction]
             goggles_frame = goggles_ani.get_frame(self.frame_index)
             goggles_frame.set_alpha(self.image_alpha)
+
+            # not needed as we've already using sick_color_effect
+            # change if goggles need to be coloured green
+            #goggles_frame = apply_sick_color_effect(goggles_frame)
+
             FBLITTER.schedule_blit(goggles_frame, rect)
 
         # display_surface.fblits(blit_list)

--- a/src/sprites/entities/sick_color_effect.py
+++ b/src/sprites/entities/sick_color_effect.py
@@ -1,0 +1,43 @@
+import pygame
+
+def apply_sick_color_effect(surf: pygame.Surface) -> pygame.Surface:
+        """Applies a green-ish tint to the player sprite to represent sickness. In a separate due to circular imports (character + player both need this function)"""
+
+        # Create a copy of the surface and ensure it has per-pixel alpha
+        sick_surface = surf.convert_alpha()
+
+        # Define color mappings from normal to sick colors
+        color_mappings = {
+            (243, 242, 192): (103, 131, 92),  # Fur Colour -> Sick Fur Colour
+            (220, 212, 220): (103, 131, 92),  # Out-group Fur Colour -> Sick Fur Colour 
+            (243, 216, 197): (86, 101, 96),  # Cheek Colour -> Sick Cheek Colour
+            (92, 78, 146): (86, 101, 96), # Out-group Cheek Colour -> Sick Cheek Colour
+            (221, 213, 222): (
+                134,
+                81,
+                97,
+            ),  # Accentuation Colour -> Sick Accentuation Colour
+            (152, 167, 212): (134, 81, 97), # Out-group Accentuation Colour -> Sick Accentuation Colour
+            (232, 181, 172): (107, 75, 91),  # Ear Colour -> Sick Ear Colour
+            (118, 109, 170): (103, 131, 92), # Out-group Ear Colour -> Sick Ear Colour
+            (192, 208, 255): (103, 131, 92), # Slightly Darker Out-group Fur Colour -> Sick Colour
+        }
+
+        # Use pixel-by-pixel replacement (slower but more compatible)
+        width = sick_surface.get_width()
+        height = sick_surface.get_height()
+        #print(f'sick colour: {width}, {height}')
+
+        for x in range(width):
+            for y in range(height):
+                pixel_color = sick_surface.get_at((x, y))
+                rgb = (pixel_color.r, pixel_color.g, pixel_color.b)
+                
+                if rgb in color_mappings:
+                    new_color = color_mappings[rgb]
+                    sick_surface.set_at((x, y), (*new_color, pixel_color.a))
+                    #print('colour mapping worked and set a value')
+
+        #print(f'sick colour returned: {sick_surface}')
+        #pygame.image.save(sick_surface, r"""C:\Users\willi\OneDrive\Desktop/imageout2.png""")
+        return sick_surface


### PR DESCRIPTION
<!-- Please delete or use (when it makes sense) the content within all HTML comments like this one before opening your pull request.
No "<!--" or "--\>" should remain.
"|" means pick any of the surrounding options. -->

## Summary

This PR fixes issue #83 that was caused by incorrect colour mappings and some blitting not using self.image. I had to create a new file for the sickness function to avoid circular imports between Character and Player.

This seems to lag slightly more on my machine, though I'm working on an old laptop. Possibly check this before merging?

<img width="307" height="244" alt="image" src="https://github.com/user-attachments/assets/4cb7e2e4-f5a3-4344-ac43-dfdb8baeb18f" />

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
bugfix-gameplay
