### PR TITLE
Add optional recovery from sickness to NPCs, #82

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ For more information, please contact s.kittelberger[at]psychologie.uzh.ch.
 
 ## Setup Instructions
 
-This project requires Python 3.12. (Python 3.13 may cause issues, and free-threaded Python is not supported.)
-
+This project requires Python 3.12. (Python 3.13 may cause issues, and free-threaded Python is not supported.)\
 PyPy is unsupported.
 
 1. **Clone this repository:**

--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -16,10 +16,9 @@ from src.gui.interface.emotes import NPCEmoteManager
 from src.npc.bases.npc_base import NPCBase
 from src.npc.behaviour.context import NPCIndividualContext, NPCSharedContext
 from src.overlay.soil import SoilManager
-from src.settings import Coordinate, SICK_INTERVAL
+from src.settings import SICK_INTERVAL, Coordinate
 from src.sprites.entities.character import Character
 from src.sprites.entities.sick_color_effect import apply_sick_color_effect
-from src.timer import Timer
 from src.sprites.setup import EntityAsset
 from src.timer import Timer
 
@@ -221,7 +220,7 @@ class NPC(NPCBase):
             self.emote_manager.show_emote(self, "cheer_ani")
             self.will_die = False
             self.die_rate = 0
-        
+
         self.recovery_timer = None
 
     # NPC sickness
@@ -240,21 +239,13 @@ class NPC(NPCBase):
             # experimental recovery interval, see settings.py
             # self.recovery_timer = Timer(
             #     RECOVERY_INTERVAL * 1000, repeat=False, autostart=True, func=self.recover
-            # ) 
+            # )
 
         # otherwise die
         else:
-          self.will_die = True
-          sickness_duration = death_tstamp - sick_tstamp
-          self.die_rate = 100 / sickness_duration
-
-    def recover(self):
-        # recover reverses the effect of get_sick, but doesn't heal any health or revive
-        if self.is_sick:
-            self.is_sick = False
-            self.emote_manager.show_emote(self, "cheer_ani")
-            self.will_die = False
-            self.die_rate = 99
+            self.will_die = True
+            sickness_duration = death_tstamp - sick_tstamp
+            self.die_rate = 100 / sickness_duration
 
     def die(self):
         self.is_dead = True
@@ -275,8 +266,8 @@ class NPC(NPCBase):
             self.image.set_alpha(self.image_alpha)
             self.health_update_callback(self)
 
-            if hasattr(self, 'recovery_timer') and self.recovery_timer:
-                self.recovery_timer.update() # doesn't take delta time, factors in itself
+            if hasattr(self, "recovery_timer") and self.recovery_timer:
+                self.recovery_timer.update()  # doesn't take delta time, factors in itself
 
             # if self.hp <= 0:
             #     self.die()

--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -225,32 +225,6 @@ class NPC(NPCBase):
         self.recovery_timer = None
 
     # NPC sickness
-<<<<<<< HEAD
-    def get_sick(
-        self, sick_tstamp: float, death_tstamp: float | None = None, recover=True
-    ):
-        # if wearing goggles, the probability of getting sick is halved
-
-        # setup recovery countdown for 5 minutes if allowed
-        if recover:
-            self.recovery_timer = Timer(
-                60 * 1000 * 5, repeat=False, autostart=True, func=self.recover
-            )
-
-        self.is_sick = True
-        self.emote_manager.show_emote(self, "sad_sick_ani")
-
-        # permanently become sick
-        if death_tstamp is None:
-            self.will_die = False
-            self.die_rate = random.randint(1, 10)
-            return
-
-        # otherwise die (or recover if recover=True and it's longer then 5 minutes)
-        self.will_die = True
-        sickness_duration = death_tstamp - sick_tstamp
-        self.die_rate = 100 / sickness_duration
-=======
     def get_sick(self, sick_tstamp: float, death_tstamp: float | None = None):
         # sick_tstamp is filled in for all cases, https://github.com/search?q=repo%3Asloukit%2Fpydew-valley-uzh-second-study+get_sick&type=code
         self.is_sick = True
@@ -273,7 +247,6 @@ class NPC(NPCBase):
           self.will_die = True
           sickness_duration = death_tstamp - sick_tstamp
           self.die_rate = 100 / sickness_duration
->>>>>>> sick-colour-optimization
 
     def recover(self):
         # recover reverses the effect of get_sick, but doesn't heal any health or revive
@@ -302,13 +275,8 @@ class NPC(NPCBase):
             self.image.set_alpha(self.image_alpha)
             self.health_update_callback(self)
 
-<<<<<<< HEAD
-            if self.recovery_timer:
-                self.recovery_timer.update()  # doesn't take delta time, factors in itself
-=======
             if hasattr(self, 'recovery_timer') and self.recovery_timer:
                 self.recovery_timer.update() # doesn't take delta time, factors in itself
->>>>>>> sick-colour-optimization
 
             # if self.hp <= 0:
             #     self.die()

--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -16,7 +16,7 @@ from src.gui.interface.emotes import NPCEmoteManager
 from src.npc.bases.npc_base import NPCBase
 from src.npc.behaviour.context import NPCIndividualContext, NPCSharedContext
 from src.overlay.soil import SoilManager
-from src.settings import SICK_INTERVAL, Coordinate
+from src.settings import RECOVERY_INTERVAL, Coordinate
 from src.sprites.entities.character import Character
 from src.sprites.entities.sick_color_effect import apply_sick_color_effect
 from src.sprites.setup import EntityAsset
@@ -232,14 +232,13 @@ class NPC(NPCBase):
         # get sick but do not die (recover)
         if sick_tstamp is None or death_tstamp is None:
             self.die_rate = random.randint(1, 10)
-            self.recovery_timer = Timer(
-                SICK_INTERVAL * 1000, repeat=False, autostart=True, func=self.recover
-            )
 
-            # experimental recovery interval, see settings.py
-            # self.recovery_timer = Timer(
-            #     RECOVERY_INTERVAL * 1000, repeat=False, autostart=True, func=self.recover
-            # )
+            self.recovery_timer = Timer(
+                RECOVERY_INTERVAL * 1000,
+                repeat=False,
+                autostart=True,
+                func=self.recover,
+            )
 
         # otherwise die
         else:

--- a/src/settings.py
+++ b/src/settings.py
@@ -172,8 +172,7 @@ MAX_HP = 100
 # interval at which to determine sickness
 # changing this is untested and may break the game, leave it at 300s / 5min if possible
 SICK_INTERVAL = 60 * 5
-# experimental interval for recovery
-# RECOVERY_INTERVAL = 60 * 5
+RECOVERY_INTERVAL = 60 * 5
 
 MIN_GOGGLE_TIME = 240  # time per each SICK INTERVAL for goggles to be effective
 


### PR DESCRIPTION
## Summary

This PR implements sickness recovery for NPCs (#82) that occurs five minutes after being infected. Uses a Timer object which works with delta time and requires minimal changes to adjust.

Note: the default value for recover=True, forcing all previous uses of get_sick() to recover unless specified. Maybe change?

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
gameplay-sickness
