### PR TITLE
Optimize apply_sick_color_effect to cache input; 6000x faster processing

### DIFF
--- a/src/sprites/entities/sick_color_effect.py
+++ b/src/sprites/entities/sick_color_effect.py
@@ -1,6 +1,54 @@
+from functools import cache
+
 import pygame
 
+# using cache
+# apply_sick_color_effect took 0.000005 seconds
+# apply_sick_color_effect took 0.000006 seconds
+# apply_sick_color_effect took 0.000006 seconds
+# apply_sick_color_effect took 0.000005 seconds
+# apply_sick_color_effect took 0.000006 seconds
+# apply_sick_color_effect took 0.000008 seconds
+# apply_sick_color_effect took 0.000005 seconds
+# apply_sick_color_effect took 0.000004 seconds
+# apply_sick_color_effect took 0.000004 seconds
+# apply_sick_color_effect took 0.000004 seconds
+# apply_sick_color_effect took 0.000004 seconds
+# apply_sick_color_effect took 0.000004 seconds
+# apply_sick_color_effect took 0.000004 seconds
+# apply_sick_color_effect took 0.000005 seconds
+# apply_sick_color_effect took 0.000003 seconds
+# apply_sick_color_effect took 0.000003 seconds
+# apply_sick_color_effect took 0.000003 seconds
+# apply_sick_color_effect took 0.000002 seconds
 
+
+# without the cache
+# apply_sick_color_effect took 0.030930 seconds
+# apply_sick_color_effect took 0.030964 seconds
+# apply_sick_color_effect took 0.032071 seconds
+# apply_sick_color_effect took 0.037817 seconds
+# apply_sick_color_effect took 0.038521 seconds
+# apply_sick_color_effect took 0.033641 seconds
+# apply_sick_color_effect took 0.040135 seconds
+# apply_sick_color_effect took 0.044454 seconds
+# apply_sick_color_effect took 0.044409 seconds
+# apply_sick_color_effect took 0.045047 seconds
+# apply_sick_color_effect took 0.043131 seconds
+# apply_sick_color_effect took 0.032540 seconds
+# apply_sick_color_effect took 0.038410 seconds
+# apply_sick_color_effect took 0.041751 seconds
+# apply_sick_color_effect took 0.042381 seconds
+# apply_sick_color_effect took 0.041693 seconds
+# apply_sick_color_effect took 0.173787 seconds
+# apply_sick_color_effect took 0.075202 seconds
+# apply_sick_color_effect took 0.081068 seconds
+# apply_sick_color_effect took 0.069109 seconds
+# apply_sick_color_effect took 0.149018 seconds
+# apply_sick_color_effect took 0.148739 seconds
+
+
+@cache
 def apply_sick_color_effect(surf: pygame.Surface) -> pygame.Surface:
     """Applies a green-ish tint to the player sprite to represent sickness. In a separate due to circular imports (character + player both need this function)"""
 
@@ -35,7 +83,6 @@ def apply_sick_color_effect(surf: pygame.Surface) -> pygame.Surface:
     # Use pixel-by-pixel replacement (slower but more compatible)
     width = sick_surface.get_width()
     height = sick_surface.get_height()
-    # print(f'sick colour: {width}, {height}')
 
     for x in range(width):
         for y in range(height):
@@ -47,6 +94,4 @@ def apply_sick_color_effect(surf: pygame.Surface) -> pygame.Surface:
                 sick_surface.set_at((x, y), (*new_color, pixel_color.a))
                 # print('colour mapping worked and set a value')
 
-    # print(f'sick colour returned: {sick_surface}')
-    # pygame.image.save(sick_surface, r"""C:\Users\willi\OneDrive\Desktop/imageout2.png""")
     return sick_surface


### PR DESCRIPTION
## Summary

For context, now that there are more things using the sick colour effect, it needs to be faster.

This PR enhances the apply sick colour effect function with simple caching. This is the same as @lru_cache(None) from functools, but with easier to read syntax (and from 3.9 instead of 3.2). 

I don't remember where the original is from, but here's the timeit function to compare:
```python
def time_it(func):
    @wraps(func) # not needed, preserves metadata for testing
    def wrapper(surf, *args, **kwargs):
        if not DEBUG_TIMING:
            return func(surf, *args, **kwargs)
        start = time.perf_counter()
        result = func(surf, *args, **kwargs)
        end = time.perf_counter()
        print(f"{func.__name__} on {surf.get_size()} took {(end - start)*1000:.3f} ms")
        return result
    return wrapper

@time_it
@cache
func here
```

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.

## Labels
type: enhancement
game-performance
