### PR TITLE
Sickness overhaul

### DIFF
--- a/main.py
+++ b/main.py
@@ -601,7 +601,7 @@ class Game:
             # this supposedly loads npc status (e.g., previous deaths etc.) but seems to be untested / not implemented server side?
             self.npc_sickness_mgr.get_status_from_server(self.jwt)
 
-            max_complete_level = 7  # debug, remove later
+            # max_complete_level = 7  # debug, remove later
             if len(day_completions) > 0:
                 timestamps = [
                     datetime.fromisoformat(d["timestamp"]) for d in day_completions

--- a/main.py
+++ b/main.py
@@ -41,7 +41,6 @@ from src.groups import AllSprites
 from src.gui.interface.dialog import DialogueManager
 from src.gui.setup import setup_gui
 from src.npc.behaviour.context import NPCSharedContext
-from src.npc.npc import NPC
 from src.npc.npcs_state_registry import NPC_STATE_REGISTRY_UPDATE_EVENT
 from src.npc_sickness_mgr import NPCSicknessManager
 from src.overlay.fast_forward import FastForward
@@ -602,7 +601,7 @@ class Game:
             # this supposedly loads npc status (e.g., previous deaths etc.) but seems to be untested / not implemented server side?
             self.npc_sickness_mgr.get_status_from_server(self.jwt)
 
-            max_complete_level = 7 # debug, remove later
+            max_complete_level = 7  # debug, remove later
             if len(day_completions) > 0:
                 timestamps = [
                     datetime.fromisoformat(d["timestamp"]) for d in day_completions

--- a/main.py
+++ b/main.py
@@ -575,7 +575,7 @@ class Game:
 
             self.npc_sickness_mgr.adherence = bool(token_int % 10)
             xplat.log(f"NPC adherence is set to {bool(token_int % 10)}")
-            self.npc_sickness_mgr._setup_from_returned_data(
+            self.npc_sickness_mgr.setup_from_db_data(
                 {"data": None}
             )  # workaround fake npc server response
             self.set_round(7)

--- a/main.py
+++ b/main.py
@@ -244,7 +244,8 @@ class Game:
             self.get_world_time,
             self.dialogue_manager,
             self.send_telemetry,
-            self.add_npc_to_mgr,
+            # self.add_npc_to_mgr,
+            self.npc_sickness_mgr.add_npc,
         )
         self.player = self.level.player
 
@@ -365,8 +366,8 @@ class Game:
         self.last_intro_txt_rendered = False
         self.switched_to_tutorial = False
 
-    def add_npc_to_mgr(self, npc_id: int, npc: NPC):
-        self.npc_sickness_mgr.add_npc(npc_id, npc)
+    # def add_npc_to_mgr(self, npc_id: int, npc: NPC):
+    #     self.npc_sickness_mgr.add_npc(npc_id, npc)
 
     def _empty_round_config_notify(self, cfg_id: str):
         self.round_config[f"notify_{cfg_id}_text"] = ""
@@ -1001,7 +1002,6 @@ class Game:
                     ):
                         self.round_config["healthbar"] = True
                         self.round_config["sickness"] = True
-                        self.npc_sickness_mgr.apply_sickness_enable_to_existing_npcs()
                         self.level.npcs_state_registry.enable()
                     elif self._can_notify_initial_gov_statement:
                         self._has_displayed_initial_gov_statement = True

--- a/main.py
+++ b/main.py
@@ -249,17 +249,12 @@ class Game:
         self.player = self.level.player
 
         # Sickness management
-        self.took_bath = False
-        self.goggles_delta = 0.0
         NPCSharedContext.get_rnd_timer = self.get_rnd_timer
         NPCSharedContext.get_round = self.get_round
         self.sickness_man = SicknessManager(
             self.player,
             self.get_round,
             self.get_rnd_timer,
-            lambda: self.goggles_delta >= 240,
-            lambda: self.took_bath,
-            self._reset_goggles_timer,
         )
 
         self.tutorial = None
@@ -369,9 +364,6 @@ class Game:
         # intro to game and in-group msg.
         self.last_intro_txt_rendered = False
         self.switched_to_tutorial = False
-
-    def _reset_goggles_timer(self):
-        self.goggles_delta = 0.0
 
     def add_npc_to_mgr(self, npc_id: int, npc: NPC):
         self.npc_sickness_mgr.add_npc(npc_id, npc)
@@ -526,8 +518,6 @@ class Game:
         return (min, sec)
 
     def send_telemetry(self, event: str, payload: dict[str, int]) -> None:
-        if event == "bath_taken":
-            self.took_bath = True
         if USE_SERVER:
             telemetry = {
                 "event": event,
@@ -650,8 +640,8 @@ class Game:
 
     def set_round(self, round_no: int) -> None:
         self.round = round_no
-        self.took_bath = False
-        self.goggles_delta = 0.0
+        self.player.took_bath = False
+        self.player.goggle_time = 0.0
         self.level.cow_herding_count = 0
         # if config for given round number not found, use first one as fall back
         if self.game_version < 0:
@@ -1128,7 +1118,7 @@ class Game:
                 self.all_sprites.update(dt)
 
             if self.player.has_goggles:
-                self.goggles_delta += dt
+                self.player.goggle_time += dt
             # this draw duplicates the same call in level.py, but without it, dialog box won't be visible
             self.all_sprites.draw(
                 self.level.camera,

--- a/main.py
+++ b/main.py
@@ -254,14 +254,11 @@ class Game:
         NPCSharedContext.get_rnd_timer = self.get_rnd_timer
         NPCSharedContext.get_round = self.get_round
         self.sickness_man = SicknessManager(
+            self.player,
             self.get_round,
             self.get_rnd_timer,
             lambda: self.goggles_delta >= 240,
             lambda: self.took_bath,
-            lambda: self.player.is_sick,
-            self.send_telemetry,
-            self.player.get_sick,
-            self.player.recover,
             self._reset_goggles_timer,
         )
 
@@ -614,7 +611,7 @@ class Game:
             # this supposedly loads npc status (e.g., previous deaths etc.) but seems to be untested / not implemented server side?
             self.npc_sickness_mgr.get_status_from_server(self.jwt)
 
-            # max_complete_level = 6
+            max_complete_level = 7 # debug, remove later
             if len(day_completions) > 0:
                 timestamps = [
                     datetime.fromisoformat(d["timestamp"]) for d in day_completions

--- a/src/client.py
+++ b/src/client.py
@@ -69,12 +69,12 @@ def send_telemetry(encoded_jwt: str, payload: dict) -> None:
     asyncio.create_task(xplat.post_request(url, headers, payload))
 
 
-async def _get_npc_status_internal(encoded_jwt: str, callback: Callable) -> dict | None:
+async def _npc_events_server_call(encoded_jwt: str, callback: Callable) -> dict | None:
     url = f"{SERVER_URL}/telemetry/npc_status/"
     headers = {"Authorization": f"Bearer {encoded_jwt}"}
     callback(await xplat.get_request(url, headers))
 
 
-def get_npc_status(encoded_jwt: str, callback: Callable) -> None:
+def get_npc_events(encoded_jwt: str, callback: Callable) -> None:
     xplat.log("Retrieving NPC status...")
-    asyncio.create_task(_get_npc_status_internal(encoded_jwt, callback))
+    asyncio.create_task(_npc_events_server_call(encoded_jwt, callback))

--- a/src/enums.py
+++ b/src/enums.py
@@ -33,9 +33,6 @@ class ItemToUse(IntEnum):
     SEED = 1
 
 
-_FT_SERIALISED_STRINGS = ("none", "axe", "hoe", "water", "corn_seed", "tomato_seed")
-
-
 class GameState(IntEnum):
     MAIN_MENU = 0
     PLAY = 1

--- a/src/gui/health_bar.py
+++ b/src/gui/health_bar.py
@@ -3,9 +3,9 @@ import random
 import pygame
 
 from src.fblitter import FBLITTER
-from src.settings import SCALE_FACTOR
+from src.settings import MAX_HP, SCALE_FACTOR
 from src.support import import_image
-from src.settings import MAX_HP
+
 
 class HealthProgressBar:
     def __init__(self, player):

--- a/src/gui/health_bar.py
+++ b/src/gui/health_bar.py
@@ -5,6 +5,7 @@ import pygame
 from src.fblitter import FBLITTER
 from src.settings import SCALE_FACTOR
 from src.support import import_image
+from src.settings import MAX_HP
 
 PLAYER_HP = "player_hp"
 PLAYER_IS_SICK = "player_is_sick"
@@ -12,7 +13,8 @@ PLAYER_HP_STATE = "player_hp_state"
 
 
 class HealthProgressBar:
-    def __init__(self, hp):
+    def __init__(self, player):
+        self.player = player
         self.pos = (80, 26)
 
         # storing all three cat images
@@ -47,9 +49,6 @@ class HealthProgressBar:
         )
         self.hp_rect.inflate_ip(0, -16)
 
-        # health points
-        self.hp = hp  # health points
-        self.max_hp = hp
         # self.per_width_hp will be substract / added as per intensity.
 
         # shake
@@ -63,7 +62,7 @@ class HealthProgressBar:
         }
 
     def render(self, screen, outgroup=False):
-        health_percent = self.hp / self.max_hp
+        health_percent = self.player.hp / MAX_HP
         # shake
         if health_percent <= 0.3:
             offset = (
@@ -112,14 +111,8 @@ class HealthProgressBar:
         FBLITTER.schedule_blit(cat_img, cat_rect.move(offset))
         # screen.blit(cat_img, (cat_rect.x + offset[0], cat_rect.y + offset[1]))
 
-    def apply_damage(self, intensity):
-        self.hp = pygame.math.clamp(self.hp - intensity, 0, self.max_hp)
-
-    def apply_health(self, intensity):
-        self.hp = pygame.math.clamp(self.hp + intensity, 0, self.max_hp)
-
     def change_color(self):
-        t = self.hp / self.max_hp
+        t = self.player.hp / MAX_HP
         if t >= 0.5:
             factor = 1 - (t - 0.5) * 2
             self.color = self.colors["Green"].lerp(self.colors["Yellow"], factor**1.5)

--- a/src/gui/health_bar.py
+++ b/src/gui/health_bar.py
@@ -7,11 +7,6 @@ from src.settings import SCALE_FACTOR
 from src.support import import_image
 from src.settings import MAX_HP
 
-PLAYER_HP = "player_hp"
-PLAYER_IS_SICK = "player_is_sick"
-PLAYER_HP_STATE = "player_hp_state"
-
-
 class HealthProgressBar:
     def __init__(self, player):
         self.player = player

--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -35,7 +35,6 @@ class NPC(NPCBase):
         soil_manager: SoilManager,
         emote_manager: NPCEmoteManager,
         tree_sprites: pygame.sprite.Group,
-        sickness_allowed: bool,
         has_hat: bool,
         has_necklace: bool,
         special_features: str | None,
@@ -67,7 +66,6 @@ class NPC(NPCBase):
         self.special_features = special_features
         self.has_horn = False
         self.has_outgroup_skin = False
-        self.sickness_allowed = sickness_allowed
 
         self.inventory = {
             InventoryResource.WOOD: 0,
@@ -115,7 +113,6 @@ class NPC(NPCBase):
 
         self.is_sick = False
         self.is_dead = False
-        self.will_die = False
         self.hp = 100
         # how fast the NPC dies after getting sick
         self.die_rate = random.randint(35, 75)
@@ -129,11 +126,6 @@ class NPC(NPCBase):
         # but not sure how to set it :-(
         self.behaviour_tree_context.allowed_seeds = seed_types
 
-    def set_sickness_allowed(self, sickness_allowed: bool) -> None:
-        self.sickness_allowed = sickness_allowed
-        if not self.sickness_allowed:
-            self.is_sick = False
-            self.hp = 100
 
     def get_personal_soil_area_tiles(self, tile_type: str) -> list[tuple[int, int]]:
         """
@@ -229,10 +221,8 @@ class NPC(NPCBase):
         self.is_sick = True
         self.emote_manager.show_emote(self, "sad_sick_ani")
         if death_tstamp is None:
-            self.will_die = False
             self.die_rate = random.randint(1, 10)
             return
-        self.will_die = True
         sickness_duration = death_tstamp - sick_tstamp
         self.die_rate = 100 / sickness_duration
 
@@ -265,8 +255,7 @@ class NPC(NPCBase):
             and self.behaviour_tree_context.adhering_to_measures
         ):
             self.has_goggles = True
-        if self.sickness_allowed:
-            self.manage_sickness(dt)
+        self.manage_sickness(dt)
         super().update(dt)
 
         self.emote_manager.update_obj(

--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -106,11 +106,6 @@ class NPC(NPCBase):
         self.assign_outfit_ingroup()
 
         # NPC health / sickness / death
-
-        self.probability_to_get_sick = (
-            0.3 if self.has_goggles else 0.6
-        ) < random.random()
-
         self.is_sick = False
         self.is_dead = False
         self.hp = 100

--- a/src/npc/npc.py
+++ b/src/npc/npc.py
@@ -121,7 +121,6 @@ class NPC(NPCBase):
         # but not sure how to set it :-(
         self.behaviour_tree_context.allowed_seeds = seed_types
 
-
     def get_personal_soil_area_tiles(self, tile_type: str) -> list[tuple[int, int]]:
         """
         Get the soil area that the NPC is responsible for (row of farmable tiles)

--- a/src/npc/npcs_state_registry.py
+++ b/src/npc/npcs_state_registry.py
@@ -43,9 +43,6 @@ class NpcsStateRegistry:
         self.last_health_update_timestamp = datetime.now()
         self._store_registry()
 
-    def get_current_time(self):
-        return datetime.now()
-
     def register_death(self, dying_npc: NPC):
         if not self.enabled:
             return

--- a/src/npc_sickness_mgr.py
+++ b/src/npc_sickness_mgr.py
@@ -18,27 +18,24 @@ from src.settings import (
     SICK_INTERVAL,
 )
 
-from src.client import get_npc_status  # noqa: F401
+from src.client import get_npc_events  # noqa: F401
 from src.enums import NPCSicknessStatusChange
 from src.npc.npc import NPC
-
-# Used to sample NPC IDs when selecting which NPCs adhere or not.
-_INGRP_ID_SAMPLING_LST = list(range(12))
-_INGRP_ID_SAMPLING = set(_INGRP_ID_SAMPLING_LST)
-_OUTGRP_ID_SAMPLING_LST = list(range(12, 24))
-_OUTGRP_ID_SAMPLING = set(_OUTGRP_ID_SAMPLING_LST)
 
 # Number of NPCs per group.
 NPC_POOL_SIZE = 12
 
+# Used to sample NPC IDs when selecting which NPCs adhere or not.
+INGRP_IDS = set(range(NPC_POOL_SIZE))
+OUTGRP_IDS = set(range(NPC_POOL_SIZE, NPC_POOL_SIZE*2))
+
 # adherent / non-adherent setting: how many adherent ingroup npc
 ADH_NPC_INGRP = [int(0.2*NPC_POOL_SIZE), int(0.8*NPC_POOL_SIZE)] # share of adhering npc if ingroup is adherent
-
 
 # Halve the NPC count for NPC adherence in the outgroup.
 _MAXIMUM_DEATH_COUNT = NPC_POOL_SIZE // 2
 
-_DEATH_LIKELIHOOD = 0.5
+_DEATH_LIKELIHOOD = 0.5 # per round, non-adhering have two dice rolls
 
 
 @dataclass
@@ -57,71 +54,41 @@ class NPCSicknessStatus:
         yield 'timestamp', self.timestamp
         yield 'change_type', self.change_type.value
 
-
-def _summarise_event(evt: NPCSicknessStatus):
-    match evt.change_type:
-        case NPCSicknessStatusChange.DIE:
-            action = "die"
-        case NPCSicknessStatusChange.SICKNESS:
-            action = "get sick"
-        case NPCSicknessStatusChange.GO_TO_BATHHOUSE:
-            return
-        case NPCSicknessStatusChange.SWITCH_TO_RECOVERY:
-            action = "recover"
-    print(
-        f"On round {evt.round_no}, after {round(evt.timestamp, 2)} seconds pass, NPC {evt.npc_id} will {action}"
-    )
+    def __str__(self):
+        return f"Rnd {self.round_no:2} TS: {round(self.timestamp, 1):6.1f}: NPC {self.npc_id:2} will {self.change_type.name}"
 
 
-def _get_death(npc_id: int, death_round: int) -> NPCSicknessStatus:
-    """Define a death timestamp for a certain NPC id."""
-    # Get sick at 5 or 10 mins (discrete possible times)
-    base_tstamp = SICK_INTERVAL * randint(1, 2)
-    final_tstamp = base_tstamp + 60 + 120 * random() # die some time after
-
+def get_sickness_evt(npc_id: int, current_round: int):
     return NPCSicknessStatus(
-        npc_id, death_round, final_tstamp, NPCSicknessStatusChange.DIE
+        npc_id, current_round, randint(1, 2) * SICK_INTERVAL, NPCSicknessStatusChange.SICKNESS
     )
 
+def get_death_and_sickness_evt_w_rand_ts(npc_id: int, death_round: int) -> tuple[NPCSicknessStatus, NPCSicknessStatus]:
+    """Define a death timestamp for an NPC id: Sick after 5 or 10mins and dead some time after"""
+    sick_evt = get_sickness_evt(npc_id, death_round)
+    die_tstamp = sick_evt.timestamp + 60 + 120 * random() # die some time after
 
-def _roll_death():
+    return (sick_evt, NPCSicknessStatus(
+        npc_id, death_round, die_tstamp, NPCSicknessStatusChange.DIE
+    ))
+
+
+def roll_death():
     return random() < _DEATH_LIKELIHOOD
 
 
-def _roll_death_count_for_ingrp(
-    current_count: int, current_round: int, adherence: bool
+def roll_death_count_for_ingrp(
+    current_round: int, adherence: bool
 ):
-    """Roll how many NPCs will die in the ingroup for the current round."""
+    """Roll how many NPCs will die in the ingroup for the current round. may need capping at max death afterwards"""
     if adherence and current_round > 9: # no deaths in this scenario
         return 0
-    computed = _roll_death()
-    if (
-        current_count + computed < _MAXIMUM_DEATH_COUNT
-        and not adherence
-        and current_round < 10
-    ):
-        computed += _roll_death() # second roll for non-adherence
-    return computed
+    n_dead = roll_death()
+    if not adherence and current_round < 10:
+        n_dead += roll_death() # second roll for non-adherence
+    return n_dead
 
 
-def _get_sickness_from_death_evt(orig_evt: NPCSicknessStatus):
-    if orig_evt.change_type != NPCSicknessStatusChange.DIE:
-        raise ValueError("Given event isn't a death event.")
-
-    orig_tstamp = orig_evt.timestamp
-    sickness_tstamp = 300 * (1 + (orig_tstamp > 600))
-    return NPCSicknessStatus(
-        orig_evt.npc_id,
-        orig_evt.round_no,
-        sickness_tstamp,
-        NPCSicknessStatusChange.SICKNESS,
-    )
-
-
-def _get_sickness(npc_id: int, current_round: int):
-    return NPCSicknessStatus(
-        npc_id, current_round, randint(1, 2) * 300, NPCSicknessStatusChange.SICKNESS
-    )
 
 
 class NPCSicknessManager:
@@ -137,312 +104,248 @@ class NPCSicknessManager:
         self.send_telemetry = send_telemetry
         self._npcs: dict[int, NPC] = {}
         self.adherence = adherence
-        self._ingrp_adhering_ids = set()
-        self._outgrp_adhering_ids = set()
+        self.ingrp_adhering_ids = set()
+        self.outgrp_adhering_ids = set()
         # Using deques so we can pull the events out as time passes in the game.
-        self.computed_status_changes: dict[int, deque[NPCSicknessStatus]] = {
-            n: deque() for n in range(7, 13)
-        }
-        self.death_tstamps: dict[int, tuple[int, float]] = {}
+        self.evt_list = []
 
     def add_npc(self, npc_id: int, obj: NPC):
         self._npcs[npc_id] = obj
-        if npc_id in self._ingrp_adhering_ids or npc_id in self._outgrp_adhering_ids:
+        if npc_id in self.ingrp_adhering_ids or npc_id in self.outgrp_adhering_ids:
             # If the NPC is supposed to adhere to the conditions, it will wear the goggles.
             # This also allows it to go to the bathhouse.
             obj.behaviour_tree_context.adhering_to_measures = True
 
     @property
-    def _next_event(self):
-        if len(self.computed_status_changes[self.get_round()])>0:
-            return self.computed_status_changes[self.get_round()][0]
+    def next_event_this_round(self):
+        if len(self.evt_list)>0 and self.evt_list[-1].round_no<=self.get_round():
+            return self.evt_list[-1]
         return None
+
+    @property
+    def ingrp_non_adh_ids(self):
+        return INGRP_IDS.difference(self.ingrp_adhering_ids)
+
+    @property
+    def outgrp_non_adh_ids(self):
+        return OUTGRP_IDS.difference(self.outgrp_adhering_ids)
+
+    def get_death_evt(self, npc_id, round=None):
+        for evt in self.evt_list[::-1]: # the list is reversed to allow popping
+            if round is not None and evt.round_no>round:
+                return None
+            if evt.change_type == NPCSicknessStatusChange.DIE and evt.npc_id==npc_id and (round is None or evt.round_no==round):
+                return evt
+        return None
+
+    def get_evtdicts_per_round(self, round):
+        ret_evts = []
+        for evt in self.evt_list[::-1]: # the list is reversed to allow popping
+            if evt.round_no==round:
+                ret_evts.append(dict(evt))
+        return ret_evts
+
+    def get_death_ids(self, round=None):
+        ids = []
+        for evt in self.evt_list[::-1]: # the list is reversed to allow popping
+            if evt.change_type == NPCSicknessStatusChange.DIE and (round is None or evt.round_no==round):
+                ids.append(evt.npc_id)
+        return ids
+
+
 
     def update_npc_status(self):
         current_round = self.get_round()
-        if current_round < 7 or self._next_event is None: # earlier rounds: do nothing, or no events left
+        if current_round < 7 or self.next_event_this_round is None: # earlier rounds: do nothing, or no events left
             return
-        timestamp = self._next_event.timestamp
+        timestamp = self.next_event_this_round.timestamp
         if timestamp > self.get_rnd_timer():
             return # Too early.
 
-        target_npc: int = self._next_event.npc_id
+        evt = self.evt_list.pop()
+        target_npc: int = evt.npc_id
 
-        match self._next_event.change_type:
+        match evt.change_type:
             case NPCSicknessStatusChange.SICKNESS:
                 # Check if the NPC is scheduled to die
-                death_tstamp = self.death_tstamps.get(target_npc)
+                death_evt = self.get_death_evt(target_npc, current_round)
                 if (
-                    death_tstamp is None
-                    or death_tstamp[0] < current_round
-                    or timestamp + 300 < death_tstamp[1]
+                    death_evt is None
+                    or timestamp + 300 < death_evt.timestamp
                 ): # regular sickness
                     self._npcs[target_npc].get_sick(timestamp)
-                    self.computed_status_changes[current_round].popleft()
-                    return
-                self._npcs[target_npc].get_sick(timestamp, death_tstamp[1])
-                self.computed_status_changes[current_round].popleft()
+                else: # sickness leading to death
+                    self._npcs[target_npc].get_sick(timestamp, death_evt.timestamp)
             case NPCSicknessStatusChange.DIE:
                 self._npcs[target_npc].die()
-                self.computed_status_changes[current_round].popleft()
             case NPCSicknessStatusChange.GO_TO_BATHHOUSE:
-                self.computed_status_changes[current_round].popleft()
+                return # debug: how does it work?
 
-    def _setup_from_returned_data(self, received: dict | None):
+    def setup_from_db_data(self, received: dict | None):
         print(received)
 
         if received is None:
             return
 
-        received_data = received["data"]
-
-        if received_data is None:
-            self.compute_sickness_events()
+        if received["data"] is None:
+            self.compute_event_list()
             return
 
-        print("=================NPC SICKNESS EVENT ORDER=====================")
-        for i, evt_list in received_data.items():
-            for evt in evt_list:
-                computed = NPCSicknessStatus(
-                    evt["npc_id"], i, evt["timestamp"], evt["change_type"]
+        print("=================NPC SICKNESS EVENTS FROM DB=====================")
+        for i, db_evt_list in received["data"].items():
+            for db_evt in db_evt_list:
+                evt = NPCSicknessStatus(
+                    db_evt["npc_id"], int(i), db_evt["timestamp"], NPCSicknessStatusChange(db_evt["change_type"])
                 )
-                self.computed_status_changes[int(i)].append(computed)
-                _summarise_event(computed)  # this print the event to the terminal
-                if computed.change_type == NPCSicknessStatusChange.DIE:
-                    self.death_tstamps[computed.npc_id] = (int(i), computed.timestamp)
-                if computed.change_type == NPCSicknessStatusChange.GO_TO_BATHHOUSE:
-                    if computed.npc_id < NPC_POOL_SIZE:
-                        self._ingrp_adhering_ids.add(computed.npc_id)
+                self.evt_list.append(evt)
+                print(str(evt))  # this print the event to the terminal
+                if evt.change_type == NPCSicknessStatusChange.GO_TO_BATHHOUSE:
+                    if evt.npc_id < NPC_POOL_SIZE:
+                        self.ingrp_adhering_ids.add(evt.npc_id)
                     else:
-                        self._outgrp_adhering_ids.add(computed.npc_id)
+                        self.outgrp_adhering_ids.add(evt.npc_id)
+        self.update_adhering_npcs_context_tree()
+        # sorting should be ok already but just to be sure...
+        self.evt_list.sort(key=lambda s: (s.round_no, s.timestamp), reverse=True)
+
+    def compute_event_list(self):
+        """Calculate all sickness-related status change events
+        for NPCs."""
+        self.select_adhering_npcs()
+
+        # Note: using copies here as we're also going to pick through those same sets of IDs to decide when other NPCs get sick.
+        self.generate_death_events()
+
+        # Pick which NPCs will suffer from nonlethal sickness in each round.
+        # All while making sure they are not already dead or sick
+        self.compute_nonlethal_sickness()
+
+        # Generate random timings for the NPCs to head to the bathhouse for each round.
+        self.compute_bathhouse_timings()
+
+        print("=================NPC SICKNESS EVENTS GENERATED=====================")
+        # Sort events in reverse, so that we can pop them from the back of the list
+        self.evt_list.sort(key=lambda s: (s.round_no, s.timestamp), reverse=True)
+        for evt in self.evt_list:
+            print(str(evt))
+
+        #Send the status to the server.
+        self.send_telemetry(
+            "npc_status",
+            {n: self.get_evtdicts_per_round(n) for n in range(7, 13)},
+        )
+
 
     def get_status_from_server(self, jwt: str):
-        get_npc_status(jwt, self._setup_from_returned_data)
+        get_npc_events(jwt, self.setup_from_db_data)
 
     # region Sickness event generation (first login)
-    def _generate_death_events(
-        self,
-        status_dict: dict[int, list[NPCSicknessStatus]],
-        ingrp_eligible: list[int],
-        outgrp_eligible: list[int],
-    ):
+    def generate_death_events(self):
         """Generate death events for the last 6 rounds."""
         ingrp_death_count = 0
         outgrp_death_count = 0
+        ingrp_eligible = list(self.ingrp_non_adh_ids)
+        outgrp_eligible = list(self.outgrp_non_adh_ids)
         for rnd in range(7, 13):
-            if (
-                ingrp_death_count >= _MAXIMUM_DEATH_COUNT
-                and outgrp_death_count >= _MAXIMUM_DEATH_COUNT
-            ):
-                # Stop doing checks if both reached the limit.
-                break
-
             if ingrp_death_count < _MAXIMUM_DEATH_COUNT:
-                curr_ingrp_rnd_deaths = _roll_death_count_for_ingrp(
-                    ingrp_death_count, rnd, self.adherence
-                )
-                if curr_ingrp_rnd_deaths>0:
-                    selected_ids = sample(ingrp_eligible, curr_ingrp_rnd_deaths)
+                new_deaths = roll_death_count_for_ingrp(rnd, self.adherence)
+                if new_deaths>0:
+                    new_deaths = min(new_deaths, _MAXIMUM_DEATH_COUNT-ingrp_death_count)
+                    selected_ids = sample(ingrp_eligible, new_deaths)
                     for npc_id in selected_ids:
-                        computed = _get_death(npc_id, rnd)
-                        status_dict[rnd].append(computed)
-                        self.death_tstamps[npc_id] = (rnd, computed.timestamp)
+                        sickness, death = get_death_and_sickness_evt_w_rand_ts(npc_id, rnd)
+                        self.evt_list += [sickness, death]
                         ingrp_eligible.remove(npc_id)
-                    ingrp_death_count += curr_ingrp_rnd_deaths
-
+                    ingrp_death_count += new_deaths
             if outgrp_death_count < _MAXIMUM_DEATH_COUNT:
-                kill_another_outgrp_npc = _roll_death()
-                if not kill_another_outgrp_npc:
-                    # Checks were already performed for the ingroup, so we can safely
-                    # jump to the next loop.
-                    continue
-                selected_npc_id = choice(outgrp_eligible)
-                computed = _get_death(selected_npc_id, rnd)
-                status_dict[rnd].append(computed)
-                self.death_tstamps[selected_npc_id] = (rnd, computed.timestamp)
-                outgrp_eligible.remove(selected_npc_id)
-                outgrp_death_count += kill_another_outgrp_npc
+                if roll_death():
+                    selected_npc_id = choice(outgrp_eligible)
+                    sickness, death = get_death_and_sickness_evt_w_rand_ts(selected_npc_id, rnd)
+                    self.evt_list += [sickness, death]
+                    outgrp_eligible.remove(selected_npc_id)
+                    outgrp_death_count += 1
 
-    def _compute_nonlethal_sickness(
-        self,
-        status_dict: dict,
-        deaths: dict,
-        ingrp_sick_eligible: list[int],
-        outgrp_sick_eligible: list[int],
-        ingrp_adherence_pickable: list[int],
-        outgrp_adherence_pickable: list[int],
-    ):
-        current_ingrp_sick_npcs = []
-        current_outgrp_sick_npcs = []
+    def compute_nonlethal_sickness(self):
+        # make copies as we will edit this
+        available_ingr_adh = set(self.ingrp_adhering_ids)
+        available_outgrp_adh = set(self.outgrp_adhering_ids)
+        available_ingr_nonadh = set(self.ingrp_non_adh_ids)
+        available_outgrp_nonadh = set(self.outgrp_non_adh_ids)
+
         for rnd in range(7, 13):
-            # Selection for the ingroup (non-adhering NPCs)
-            if ingrp_sick_eligible:
-                for dead_id in deaths[rnd][0]:
-                    try:
-                        ingrp_sick_eligible.remove(dead_id)
-                    except ValueError:
-                        pass
+            # dying npcs for this round (remove from sickness possibility)
+            die_ids = self.get_death_ids(round=rnd)
+            print("die ids round {} {}".format(rnd, die_ids))
+            # ingroup non-adhering
+            available_ingr_nonadh = available_ingr_nonadh.difference(die_ids)
+            sick_count = len(available_ingr_nonadh)-1 # all but one get sick
+            if not self.adherence and rnd >=10:
+                sick_count -= 2
+            if sick_count > 0:
+                sick_ids = sample(list(available_ingr_nonadh), sick_count)
+                for sick_id in sick_ids:
+                    self.evt_list.append(get_sickness_evt(sick_id, rnd))
 
-                nominal_target_count = (
-                    2
-                    + 4 * (not self.adherence)
-                    + 2 * (not self.adherence and rnd < 10)
-                    - len(deaths[rnd][0])
-                )
+            # ingroup adhering: one per round and at
+            if len(available_ingr_adh) > 0:
+                sick_id = choice(list(available_ingr_adh))
+                available_ingr_adh.remove(sick_id)
+                self.evt_list.append(get_sickness_evt(sick_id, rnd))
 
-                actual_sample_length = min(
-                    len(ingrp_sick_eligible), nominal_target_count
-                )
-                if actual_sample_length:
-                    current_ingrp_sick_npcs = sample(
-                        ingrp_sick_eligible, actual_sample_length
-                    )
-                else:
-                    current_ingrp_sick_npcs.clear()
 
-            # Selection for the ingroup (adhering NPCs)
-            if len(ingrp_adherence_pickable) > 0:
-                current_ingrp_adherent = choice(ingrp_adherence_pickable)
-                ingrp_adherence_pickable.remove(current_ingrp_adherent)
-                current_ingrp_sick_npcs.append(current_ingrp_adherent)
+            # outgroup non-adhering
+            available_outgrp_nonadh = available_outgrp_nonadh.difference(die_ids)
+            sick_count = len(available_outgrp_nonadh)-1 # all but one get sick
+            if rnd >=10:
+                sick_count -= 1
+            if sick_count > 0:
+                sick_ids = sample(list(available_outgrp_nonadh), sick_count)
+                for sick_id in sick_ids:
+                    self.evt_list.append(get_sickness_evt(sick_id, rnd))
 
-            # Selection for the outgroup (non-adhering NPCs)
-            if outgrp_sick_eligible:
-                for dead_id in deaths[rnd][1]:
-                    try:
-                        outgrp_sick_eligible.remove(dead_id)
-                    except ValueError:
-                        pass
+            # outgroup adhering: one per round and at
+            if len(available_outgrp_adh) > 0:
+                sick_id = choice(list(available_outgrp_adh))
+                available_outgrp_adh.remove(sick_id)
+                self.evt_list.append(get_sickness_evt(sick_id, rnd))
 
-                nominal_target_count = 4 + (rnd < 10) - len(deaths[rnd][1])
-                actual_sample_length = min(
-                    len(outgrp_sick_eligible), nominal_target_count
-                )
-
-                if actual_sample_length:
-                    current_outgrp_sick_npcs = sample(
-                        outgrp_sick_eligible, actual_sample_length
-                    )
-                else:
-                    current_outgrp_sick_npcs.clear()
-
-            # Selection for the outgroup (adhering NPCs)
-            current_outgrp_adherent = choice(outgrp_adherence_pickable)
-            outgrp_adherence_pickable.remove(current_outgrp_adherent)
-            current_outgrp_sick_npcs.append(current_outgrp_adherent)
-
-            # Generate all the sickness start events in one fell swoop.
-            for npc_id in chain(current_ingrp_sick_npcs, current_outgrp_sick_npcs):
-                status_dict[rnd].append(_get_sickness(npc_id, rnd))
-
-    def _compute_bathhouse_timings(self, status_dict: dict):
-        """Generate bathhouse timings for each adhering NPC in both groups."""
-        ingrp_pickable = self._ingrp_adhering_ids
-        outgrp_pickable = self._outgrp_adhering_ids
-        for rnd in range(7, 13):
-            for npc_id in chain(ingrp_pickable, outgrp_pickable):
-                # It is assumed an NPC takes 45 seconds to leave the map and come back in all instances.
-                if rnd == 7:
-                    # Allowed range for bathhouse access: 1 minute (60 seconds) to 5 minutes (300 seconds).
-                    # i.e. the allowed timeframe is 240 seconds long.
-                    # Since an NPC takes 45 seconds to go to the bathhouse, take the bath and then come back,
-                    # the allowed range for NPCs to go to the bathhouse is only 195 seconds long.
-                    bathhouse_tstamp = (
-                        random() * 195 + 60
-                    )  # Add 1 minute to the rolled duration.
-                else:
-                    # Allowed range in all other rounds: until 3 minutes after round start.
-                    # Again, since an NPC takes 45 seconds to go take the bath, that leaves only
-                    # 135 seconds worth of time to roll a bathhouse moment.
-                    bathhouse_tstamp = random() * 135
-                status_dict[rnd].append(
-                    NPCSicknessStatus(
+    def get_bath_evt(self, npc_id, rnd, s, e):
+        t = s+random()*(e-s)
+        return  NPCSicknessStatus(
                         npc_id,
                         rnd,
-                        bathhouse_tstamp,
+                        t,
                         NPCSicknessStatusChange.GO_TO_BATHHOUSE,
                     )
-                )
+    def compute_bathhouse_timings(self):
+        """Generate bathhouse timings for each adhering NPC in both groups."""
+        adhering_ids = self.ingrp_adhering_ids.union(self.outgrp_adhering_ids)
+        for rnd in range(7, 13):
+            for npc_id in adhering_ids:
+                # It is assumed an NPC takes 45 seconds to leave the map and come back in all instances.
+                if rnd == 7:
+                    # earliest leaving after 60s, latest return after 300s, start between 60 and 255s
+                    self.evt_list.append(self.get_bath_evt(npc_id, rnd, 60, 255))
+                else:
+                    # be back after 180s, leave before 135s
+                    self.evt_list.append(self.get_bath_evt(npc_id, rnd, 0, 135))
 
-    def _compute_npc_status(self):
-        """Calculate all sickness-related status change events
-        for NPCs."""
-        ingrp_adherence_pickable = list(self._ingrp_adhering_ids)
-        outgrp_adherence_pickable = list(self._outgrp_adhering_ids)
-
-        status_changes: dict[int, list[NPCSicknessStatus]] = { #split into rounds
-            n: [] for n in range(7, 13)
-        }
-
-        deaths = {n: ([], []) for n in range(7, 13)}
-
-        # For each group, select which NPCs are going to die first.
-        ingrp_sick_death_eligible = list(
-            _INGRP_ID_SAMPLING.difference(self._ingrp_adhering_ids)
-        )
-        outgrp_sick_death_eligible = list(
-            _OUTGRP_ID_SAMPLING.difference(self._outgrp_adhering_ids)
-        )
-
-        # Note: using copies here as we're also going to pick through those same sets of IDs to decide when other NPCs get sick.
-        self._generate_death_events(
-            status_changes,
-            ingrp_sick_death_eligible.copy(),
-            outgrp_sick_death_eligible.copy(),
-        )
-
-        # Next, we generate sickness events for NPCs scheduled to die in their death round.
-        # These will then be removed from sampling for the current round, and once the death round is reached
-        # when selecting other NPCs to fall sick in said round, removed from the eligible pool entirely.
-        for death_event in chain.from_iterable(status_changes.values()):
-            if death_event.change_type != NPCSicknessStatusChange.DIE:
-                continue
-            status_changes[death_event.round_no].append(
-                _get_sickness_from_death_evt(death_event)
-            )
-
-            current_npc = death_event.npc_id
-            is_ingrp = current_npc < NPC_POOL_SIZE
-            deaths[death_event.round_no][not is_ingrp].append(death_event.npc_id)
-
-        # Pick which NPCs will suffer from nonlethal sickness in each round.
-        self._compute_nonlethal_sickness(
-            status_changes,
-            deaths,
-            ingrp_sick_death_eligible,
-            outgrp_sick_death_eligible,
-            ingrp_adherence_pickable,
-            outgrp_adherence_pickable,
-        )
-
-        # Generate random timings for the NPCs to head to the bathhouse for each round.
-        self._compute_bathhouse_timings(status_changes)
-
-        # Sort all NPC sickness events by timestamp in each round's list and then put them in the queues in that order.
-        for round_no, event_list in status_changes.items():
-            event_list.sort(key=lambda evt: evt.timestamp)
-            self.computed_status_changes[round_no].extend(event_list)
-
-        # Send the status to the server.
-        self.send_telemetry(
-            "npc_status",
-            {n: [dict(evt) for evt in val] for n, val in status_changes.items()},
-        )
+    def update_adhering_npcs_context_tree(self):
+        for id in self.ingrp_adhering_ids | self.outgrp_adhering_ids:
+            if id in self._npcs:
+                self._npcs[id].behaviour_tree_context.adhering_to_measures = True
 
     def select_adhering_npcs(self):
         """Determine which NPCs adhere to the health measures.
 
         The adherence parameter only affects the ingroup.
         The outgroup always has a 50/50 proportion of adherence."""
-        self._ingrp_adhering_ids = set(
-            sample(_INGRP_ID_SAMPLING_LST, ADH_NPC_INGRP[self.adherence])
+        self.ingrp_adhering_ids = set(
+            sample(list(INGRP_IDS), ADH_NPC_INGRP[self.adherence])
         )
-        self._outgrp_adhering_ids = set(
-            sample(_OUTGRP_ID_SAMPLING_LST, NPC_POOL_SIZE // 2)
+        self.outgrp_adhering_ids = set(
+            sample(list(OUTGRP_IDS), NPC_POOL_SIZE // 2)
         )
-
-    def compute_sickness_events(self):
-        self.select_adhering_npcs()
-        self._compute_npc_status()
+        self.update_adhering_npcs_context_tree()
 
     # endregion

--- a/src/npc_sickness_mgr.py
+++ b/src/npc_sickness_mgr.py
@@ -7,35 +7,34 @@ get sick and whether they will die or recover on the fly.
 For adhering NPCs, it will also be decided when the NPCs go to the bathhouse this way."""
 
 import asyncio  # noqa: F401
-from collections import deque
 from dataclasses import dataclass
-from itertools import chain
-from math import ceil, floor
 from random import choice, randint, random, sample
 from typing import Callable
-
-from src.settings import (
-    SICK_INTERVAL,
-)
 
 from src.client import get_npc_events  # noqa: F401
 from src.enums import NPCSicknessStatusChange
 from src.npc.npc import NPC
+from src.settings import (
+    SICK_INTERVAL,
+)
 
 # Number of NPCs per group.
 NPC_POOL_SIZE = 12
 
 # Used to sample NPC IDs when selecting which NPCs adhere or not.
 INGRP_IDS = set(range(NPC_POOL_SIZE))
-OUTGRP_IDS = set(range(NPC_POOL_SIZE, NPC_POOL_SIZE*2))
+OUTGRP_IDS = set(range(NPC_POOL_SIZE, NPC_POOL_SIZE * 2))
 
 # adherent / non-adherent setting: how many adherent ingroup npc
-ADH_NPC_INGRP = [int(0.2*NPC_POOL_SIZE), int(0.8*NPC_POOL_SIZE)] # share of adhering npc if ingroup is adherent
+ADH_NPC_INGRP = [
+    int(0.2 * NPC_POOL_SIZE),
+    int(0.8 * NPC_POOL_SIZE),
+]  # share of adhering npc if ingroup is adherent
 
 # Halve the NPC count for NPC adherence in the outgroup.
 _MAXIMUM_DEATH_COUNT = NPC_POOL_SIZE // 2
 
-_DEATH_LIKELIHOOD = 0.5 # per round, non-adhering have two dice rolls
+_DEATH_LIKELIHOOD = 0.5  # per round, non-adhering have two dice rolls
 
 
 @dataclass
@@ -47,12 +46,11 @@ class NPCSicknessStatus:
     timestamp: float
     change_type: NPCSicknessStatusChange
 
-
     def __iter__(self):
         # Yield key-value pairs to allow dict(NPCSicknessStatus_object)
-        yield 'npc_id', self.npc_id
-        yield 'timestamp', self.timestamp
-        yield 'change_type', self.change_type.value
+        yield "npc_id", self.npc_id
+        yield "timestamp", self.timestamp
+        yield "change_type", self.change_type.value
 
     def __str__(self):
         return f"Rnd {self.round_no:2} TS: {round(self.timestamp, 1):6.1f}: NPC {self.npc_id:2} will {self.change_type.name}"
@@ -60,35 +58,38 @@ class NPCSicknessStatus:
 
 def get_sickness_evt(npc_id: int, current_round: int):
     return NPCSicknessStatus(
-        npc_id, current_round, randint(1, 2) * SICK_INTERVAL, NPCSicknessStatusChange.SICKNESS
+        npc_id,
+        current_round,
+        randint(1, 2) * SICK_INTERVAL,
+        NPCSicknessStatusChange.SICKNESS,
     )
 
-def get_death_and_sickness_evt_w_rand_ts(npc_id: int, death_round: int) -> tuple[NPCSicknessStatus, NPCSicknessStatus]:
+
+def get_death_and_sickness_evt_w_rand_ts(
+    npc_id: int, death_round: int
+) -> tuple[NPCSicknessStatus, NPCSicknessStatus]:
     """Define a death timestamp for an NPC id: Sick after 5 or 10mins and dead some time after"""
     sick_evt = get_sickness_evt(npc_id, death_round)
-    die_tstamp = sick_evt.timestamp + 60 + 120 * random() # die some time after
+    die_tstamp = sick_evt.timestamp + 60 + 120 * random()  # die some time after
 
-    return (sick_evt, NPCSicknessStatus(
-        npc_id, death_round, die_tstamp, NPCSicknessStatusChange.DIE
-    ))
+    return (
+        sick_evt,
+        NPCSicknessStatus(npc_id, death_round, die_tstamp, NPCSicknessStatusChange.DIE),
+    )
 
 
 def roll_death():
     return random() < _DEATH_LIKELIHOOD
 
 
-def roll_death_count_for_ingrp(
-    current_round: int, adherence: bool
-):
+def roll_death_count_for_ingrp(current_round: int, adherence: bool):
     """Roll how many NPCs will die in the ingroup for the current round. may need capping at max death afterwards"""
-    if adherence and current_round > 9: # no deaths in this scenario
+    if adherence and current_round > 9:  # no deaths in this scenario
         return 0
     n_dead = roll_death()
     if not adherence and current_round < 10:
-        n_dead += roll_death() # second roll for non-adherence
+        n_dead += roll_death()  # second roll for non-adherence
     return n_dead
-
-
 
 
 class NPCSicknessManager:
@@ -118,7 +119,7 @@ class NPCSicknessManager:
 
     @property
     def next_event_this_round(self):
-        if len(self.evt_list)>0 and self.evt_list[-1].round_no<=self.get_round():
+        if len(self.evt_list) > 0 and self.evt_list[-1].round_no <= self.get_round():
             return self.evt_list[-1]
         return None
 
@@ -131,36 +132,42 @@ class NPCSicknessManager:
         return OUTGRP_IDS.difference(self.outgrp_adhering_ids)
 
     def get_death_evt(self, npc_id, round=None):
-        for evt in self.evt_list[::-1]: # the list is reversed to allow popping
-            if round is not None and evt.round_no>round:
+        for evt in self.evt_list[::-1]:  # the list is reversed to allow popping
+            if round is not None and evt.round_no > round:
                 return None
-            if evt.change_type == NPCSicknessStatusChange.DIE and evt.npc_id==npc_id and (round is None or evt.round_no==round):
+            if (
+                evt.change_type == NPCSicknessStatusChange.DIE
+                and evt.npc_id == npc_id
+                and (round is None or evt.round_no == round)
+            ):
                 return evt
         return None
 
     def get_evtdicts_per_round(self, round):
         ret_evts = []
-        for evt in self.evt_list[::-1]: # the list is reversed to allow popping
-            if evt.round_no==round:
+        for evt in self.evt_list[::-1]:  # the list is reversed to allow popping
+            if evt.round_no == round:
                 ret_evts.append(dict(evt))
         return ret_evts
 
     def get_death_ids(self, round=None):
         ids = []
-        for evt in self.evt_list[::-1]: # the list is reversed to allow popping
-            if evt.change_type == NPCSicknessStatusChange.DIE and (round is None or evt.round_no==round):
+        for evt in self.evt_list[::-1]:  # the list is reversed to allow popping
+            if evt.change_type == NPCSicknessStatusChange.DIE and (
+                round is None or evt.round_no == round
+            ):
                 ids.append(evt.npc_id)
         return ids
 
-
-
     def update_npc_status(self):
         current_round = self.get_round()
-        if current_round < 7 or self.next_event_this_round is None: # earlier rounds: do nothing, or no events left
+        if (
+            current_round < 7 or self.next_event_this_round is None
+        ):  # earlier rounds: do nothing, or no events left
             return
         timestamp = self.next_event_this_round.timestamp
         if timestamp > self.get_rnd_timer():
-            return # Too early.
+            return  # Too early.
 
         evt = self.evt_list.pop()
         target_npc: int = evt.npc_id
@@ -170,16 +177,15 @@ class NPCSicknessManager:
                 # Check if the NPC is scheduled to die
                 death_evt = self.get_death_evt(target_npc, current_round)
                 if (
-                    death_evt is None
-                    or timestamp + 300 < death_evt.timestamp
-                ): # regular sickness
+                    death_evt is None or timestamp + 300 < death_evt.timestamp
+                ):  # regular sickness
                     self._npcs[target_npc].get_sick(timestamp)
-                else: # sickness leading to death
+                else:  # sickness leading to death
                     self._npcs[target_npc].get_sick(timestamp, death_evt.timestamp)
             case NPCSicknessStatusChange.DIE:
                 self._npcs[target_npc].die()
             case NPCSicknessStatusChange.GO_TO_BATHHOUSE:
-                return # debug: how does it work?
+                return  # debug: how does it work?
 
     def setup_from_db_data(self, received: dict | None):
         print(received)
@@ -195,7 +201,10 @@ class NPCSicknessManager:
         for i, db_evt_list in received["data"].items():
             for db_evt in db_evt_list:
                 evt = NPCSicknessStatus(
-                    db_evt["npc_id"], int(i), db_evt["timestamp"], NPCSicknessStatusChange(db_evt["change_type"])
+                    db_evt["npc_id"],
+                    int(i),
+                    db_evt["timestamp"],
+                    NPCSicknessStatusChange(db_evt["change_type"]),
                 )
                 self.evt_list.append(evt)
                 print(str(evt))  # this print the event to the terminal
@@ -229,12 +238,11 @@ class NPCSicknessManager:
         for evt in self.evt_list:
             print(str(evt))
 
-        #Send the status to the server.
+        # Send the status to the server.
         self.send_telemetry(
             "npc_status",
             {n: self.get_evtdicts_per_round(n) for n in range(7, 13)},
         )
-
 
     def get_status_from_server(self, jwt: str):
         get_npc_events(jwt, self.setup_from_db_data)
@@ -249,18 +257,24 @@ class NPCSicknessManager:
         for rnd in range(7, 13):
             if ingrp_death_count < _MAXIMUM_DEATH_COUNT:
                 new_deaths = roll_death_count_for_ingrp(rnd, self.adherence)
-                if new_deaths>0:
-                    new_deaths = min(new_deaths, _MAXIMUM_DEATH_COUNT-ingrp_death_count)
+                if new_deaths > 0:
+                    new_deaths = min(
+                        new_deaths, _MAXIMUM_DEATH_COUNT - ingrp_death_count
+                    )
                     selected_ids = sample(ingrp_eligible, new_deaths)
                     for npc_id in selected_ids:
-                        sickness, death = get_death_and_sickness_evt_w_rand_ts(npc_id, rnd)
+                        sickness, death = get_death_and_sickness_evt_w_rand_ts(
+                            npc_id, rnd
+                        )
                         self.evt_list += [sickness, death]
                         ingrp_eligible.remove(npc_id)
                     ingrp_death_count += new_deaths
             if outgrp_death_count < _MAXIMUM_DEATH_COUNT:
                 if roll_death():
                     selected_npc_id = choice(outgrp_eligible)
-                    sickness, death = get_death_and_sickness_evt_w_rand_ts(selected_npc_id, rnd)
+                    sickness, death = get_death_and_sickness_evt_w_rand_ts(
+                        selected_npc_id, rnd
+                    )
                     self.evt_list += [sickness, death]
                     outgrp_eligible.remove(selected_npc_id)
                     outgrp_death_count += 1
@@ -278,8 +292,8 @@ class NPCSicknessManager:
             print("die ids round {} {}".format(rnd, die_ids))
             # ingroup non-adhering
             available_ingr_nonadh = available_ingr_nonadh.difference(die_ids)
-            sick_count = len(available_ingr_nonadh)-1 # all but one get sick
-            if not self.adherence and rnd >=10:
+            sick_count = len(available_ingr_nonadh) - 1  # all but one get sick
+            if not self.adherence and rnd >= 10:
                 sick_count -= 2
             if sick_count > 0:
                 sick_ids = sample(list(available_ingr_nonadh), sick_count)
@@ -292,11 +306,10 @@ class NPCSicknessManager:
                 available_ingr_adh.remove(sick_id)
                 self.evt_list.append(get_sickness_evt(sick_id, rnd))
 
-
             # outgroup non-adhering
             available_outgrp_nonadh = available_outgrp_nonadh.difference(die_ids)
-            sick_count = len(available_outgrp_nonadh)-1 # all but one get sick
-            if rnd >=10:
+            sick_count = len(available_outgrp_nonadh) - 1  # all but one get sick
+            if rnd >= 10:
                 sick_count -= 1
             if sick_count > 0:
                 sick_ids = sample(list(available_outgrp_nonadh), sick_count)
@@ -310,13 +323,14 @@ class NPCSicknessManager:
                 self.evt_list.append(get_sickness_evt(sick_id, rnd))
 
     def get_bath_evt(self, npc_id, rnd, s, e):
-        t = s+random()*(e-s)
-        return  NPCSicknessStatus(
-                        npc_id,
-                        rnd,
-                        t,
-                        NPCSicknessStatusChange.GO_TO_BATHHOUSE,
-                    )
+        t = s + random() * (e - s)
+        return NPCSicknessStatus(
+            npc_id,
+            rnd,
+            t,
+            NPCSicknessStatusChange.GO_TO_BATHHOUSE,
+        )
+
     def compute_bathhouse_timings(self):
         """Generate bathhouse timings for each adhering NPC in both groups."""
         adhering_ids = self.ingrp_adhering_ids.union(self.outgrp_adhering_ids)
@@ -343,9 +357,7 @@ class NPCSicknessManager:
         self.ingrp_adhering_ids = set(
             sample(list(INGRP_IDS), ADH_NPC_INGRP[self.adherence])
         )
-        self.outgrp_adhering_ids = set(
-            sample(list(OUTGRP_IDS), NPC_POOL_SIZE // 2)
-        )
+        self.outgrp_adhering_ids = set(sample(list(OUTGRP_IDS), NPC_POOL_SIZE // 2))
         self.update_adhering_npcs_context_tree()
 
     # endregion

--- a/src/overlay/overlay.py
+++ b/src/overlay/overlay.py
@@ -40,7 +40,7 @@ class Overlay:
         self.visible = True
 
         # ui objects
-        self.health_bar = HealthProgressBar(100)
+        self.health_bar = HealthProgressBar(self.player)
 
         self.clock = Clock(game_time, get_world_time, ClockVersion.DIGITAL)
         self.FPS = FPS(clock)

--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -401,7 +401,6 @@ class GameMap:
 
         self.number_of_hats_to_exclude = 2
         for npc in self.npcs:
-            npc.set_sickness_allowed(self.round_config.get("sickness", False))
             npc.set_allowed_seeds(allowed_seeds)
             npc.assign_outfit_ingroup(
                 self.round_config.get("ingroup_40p_hat_necklace_appearance", False)
@@ -751,7 +750,6 @@ class GameMap:
             soil_manager=self.soil_manager,
             emote_manager=self.npc_emote_manager,
             tree_sprites=self.tree_sprites,
-            sickness_allowed=self.round_config.get("sickness", False),
             has_hat=has_hat,
             has_necklace=has_necklace,
             special_features=features,

--- a/src/screens/game_map.py
+++ b/src/screens/game_map.py
@@ -776,8 +776,6 @@ class GameMap:
         if gmap == Map.MINIGAME and obj.name and obj.name == "opponent":
             if npc.study_group == self.player.study_group:
                 npc.kill()
-        if gmap == Map.MINIGAME:
-            npc.probability_to_get_sick = 1
 
         cheering = gmap == Map.MINIGAME
 

--- a/src/screens/inventory.py
+++ b/src/screens/inventory.py
@@ -278,11 +278,10 @@ class InventoryMenu(AbstractMenu):
                 ):
                     btn.selected = btn.text == text
         if text == "goggles":
-            has_goggles = not self.player.has_goggles
-            self.player.has_goggles = has_goggles
+            self.player.has_goggles = not self.player.has_goggles
             for btn in self._special_btns:
                 if btn.text == "goggles":
-                    btn.selected = has_goggles
+                    btn.selected = self.player.has_goggles
                     break
 
     def button_setup(self, player):

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -246,7 +246,6 @@ class Level:
             interact=self.interact,
             emote_manager=self.player_emote_manager,
             sounds=self.sounds,
-            hp=0,
             bath_time=0,
             save_file=self.save_file,
             round_config=self.round_config,
@@ -1339,7 +1338,6 @@ class Level:
         self.overlay.display()
 
     def draw(self, dt: float, move_things: bool):
-        self.player.hp = self.overlay.health_bar.hp
         # self.display_surface.fill((130, 168, 132))
         self.all_sprites.draw(self.camera, False)
 
@@ -1454,8 +1452,6 @@ class Level:
                 ),
                 dt,
             )
-            if self.round_config.get("sickness", False) and self.player.is_sick:
-                self.decay_health(dt)
 
         self.draw(dt, move_things)
 

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -33,7 +33,6 @@ from src.events import (
 from src.exceptions import GameMapWarning
 from src.fblitter import FBLITTER
 from src.groups import AllSprites, PersistentSpriteGroup
-from src.gui.health_bar import PLAYER_HP, PLAYER_HP_STATE, PLAYER_IS_SICK
 from src.gui.interface.dialog import DialogueManager
 from src.gui.interface.emotes import NPCEmoteManager, PlayerEmoteManager
 from src.gui.scene_animation import SceneAnimation
@@ -63,6 +62,10 @@ from src.settings import (
     VOLCANO_POS,
     MapDict,
     SoundDict,
+    PLAYER_HP_STR,
+    PLAYER_HP_STATE_STR,
+    PLAYER_IS_SICK_STR,
+    PLAYER_IS_BSICK_STR,
 )
 from src.sprites.base import AnimatedSprite, Sprite
 from src.sprites.bath_bubble import BubbleMgr
@@ -246,7 +249,6 @@ class Level:
             interact=self.interact,
             emote_manager=self.player_emote_manager,
             sounds=self.sounds,
-            bath_time=0,
             save_file=self.save_file,
             round_config=self.round_config,
             get_game_version=get_game_version,
@@ -509,7 +511,11 @@ class Level:
 
     def warp_to_map(self, map_name: str):
         if map_name == "bathhouse":
-            self.send_telemetry("bath_taken", {})
+            if not(self.player.is_bath_sick or self.player.is_sick):
+                self.player.get_bath_sick(self.get_rnd_timer())
+                self.send_telemetry("bath_taken", {"has_effect":True})
+            else:
+                self.send_telemetry("bath_taken", {"has_effect":False})
             self.bubble_mgr.start()
         if map_name == "minigame":
             self.cow_herding_count += 1
@@ -533,17 +539,7 @@ class Level:
         else:
             if map_name == "bathhouse":
                 if self.round_config["accessible_bathhouse"]:
-                    if self.player.hp < 80:
-                        self.player.bathstat = True
-                        self.send_telemetry(
-                            PLAYER_HP_STATE,
-                            {
-                                PLAYER_HP: self.player.hp,
-                                PLAYER_IS_SICK: self.player.is_sick,
-                            },
-                        )
-                        self.player.bath_time = time.time()
-                    self.player.emote_manager.show_emote(self.player, "sad_sick_ani")
+                    # self.player.emote_manager.show_emote(self.player, "sad_sick_ani")
                     self.load_map(self.current_map, from_map=map_name)
             else:
                 warnings.warn(f'Error loading map: Map "{map_name}" not found')
@@ -1226,13 +1222,6 @@ class Level:
     def start_map_transition(self):
         self.map_transition.activate()
         self.start_transition()
-
-    def decay_health(self, dt):
-        if self.player.is_sick:
-            if int(self.get_rnd_timer()) % 300 < 150:  # first 2.5 mins decrease health
-                self.overlay.health_bar.apply_damage(90 / 150 * dt)
-            else:  # second 2.5mins increase health again
-                self.overlay.health_bar.apply_health(90 / 150 * dt)
 
     def check_map_exit(self):
         if not self.map_transition:

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -1,6 +1,5 @@
 import gc
 import random
-import time
 import warnings
 from collections.abc import Callable
 from functools import partial
@@ -507,11 +506,11 @@ class Level:
 
     def warp_to_map(self, map_name: str):
         if map_name == "bathhouse":
-            if not(self.player.is_bath_sick or self.player.is_sick):
+            if not (self.player.is_bath_sick or self.player.is_sick):
                 self.player.get_bath_sick(self.get_rnd_timer())
-                self.send_telemetry("bath_taken", {"has_effect":True})
+                self.send_telemetry("bath_taken", {"has_effect": True})
             else:
-                self.send_telemetry("bath_taken", {"has_effect":False})
+                self.send_telemetry("bath_taken", {"has_effect": False})
             self.bubble_mgr.start()
         if map_name == "minigame":
             self.cow_herding_count += 1

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -62,10 +62,6 @@ from src.settings import (
     VOLCANO_POS,
     MapDict,
     SoundDict,
-    PLAYER_HP_STR,
-    PLAYER_HP_STATE_STR,
-    PLAYER_IS_SICK_STR,
-    PLAYER_IS_BSICK_STR,
 )
 from src.sprites.base import AnimatedSprite, Sprite
 from src.sprites.bath_bubble import BubbleMgr

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -195,7 +195,6 @@ class CowHerding(Minigame):
             soil_manager=self._state.game_map.soil_manager,
             emote_manager=self._state.game_map.npc_emote_manager,
             tree_sprites=pygame.sprite.Group(),
-            sickness_allowed=self.round_config.get("sickness", False),
             npc_id=40,
             has_hat=False,
             has_necklace=False,

--- a/src/screens/minigames/cow_herding.py
+++ b/src/screens/minigames/cow_herding.py
@@ -200,7 +200,6 @@ class CowHerding(Minigame):
             has_necklace=False,
             special_features=None,
         )
-        opponent.probability_to_get_sick = 1
         self._state.game_map.npcs.append(opponent)
         side_map = {StudyGroup.INGROUP: "L", StudyGroup.OUTGROUP: "R"}
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -163,3 +163,36 @@ TOMATO_OR_CORN_LIST = [
 # Used in player.py
 # Changing the divisor with the minimum supported FPS will result in different tolerated lag spikes
 MAX_DT: Final[float] = 1.0 / 12.0
+
+
+# health related
+#=================
+MAX_HP = 100
+
+# interval at which to determine sickness
+# changing this is untested and may break the game, leave it at 300s / 5min if possible
+SICK_INTERVAL = 300
+
+MIN_GOGGLE_TIME = 240 # time per each SICK INTERVAL for goggles to be effective
+
+# regular sickness
+SICK_DURATION = 240 # duration of sickness
+SICK_DECLINE = 120 # decline time of sickness
+SICK_INCLINE = SICK_DURATION-SICK_DECLINE # incline time of sickness
+SICK_MIN_HP = 10 #min hp to go to
+
+# sickness after bath
+BSICK_DURATION = 60 # duration of sickness
+BSICK_DECLINE = 30 # decline time of sickness
+BSICK_INCLINE = SICK_DURATION-SICK_DECLINE # incline time of sickness
+BSICK_MIN_HP = 50 #min hp to go to
+
+
+# db logging terms
+PLAYER_HP_STR = "player_hp"
+PLAYER_IS_SICK_STR = "player_is_sick"
+PLAYER_IS_BSICK_STR = "player_is_bath_sick"
+PLAYER_HP_STATE_STR = "player_hp_state"
+
+
+

--- a/src/settings.py
+++ b/src/settings.py
@@ -166,26 +166,26 @@ MAX_DT: Final[float] = 1.0 / 12.0
 
 
 # health related
-#=================
+# =================
 MAX_HP = 100
 
 # interval at which to determine sickness
 # changing this is untested and may break the game, leave it at 300s / 5min if possible
 SICK_INTERVAL = 300
 
-MIN_GOGGLE_TIME = 240 # time per each SICK INTERVAL for goggles to be effective
+MIN_GOGGLE_TIME = 240  # time per each SICK INTERVAL for goggles to be effective
 
 # regular sickness
-SICK_DURATION = 240 # duration of sickness
-SICK_DECLINE = 120 # decline time of sickness
-SICK_INCLINE = SICK_DURATION-SICK_DECLINE # incline time of sickness
-SICK_MIN_HP = 10 #min hp to go to
+SICK_DURATION = 240  # duration of sickness
+SICK_DECLINE = 120  # decline time of sickness
+SICK_INCLINE = SICK_DURATION - SICK_DECLINE  # incline time of sickness
+SICK_MIN_HP = 10  # min hp to go to
 
 # sickness after bath
-BSICK_DURATION = 60 # duration of sickness
-BSICK_DECLINE = 30 # decline time of sickness
-BSICK_INCLINE = SICK_DURATION-SICK_DECLINE # incline time of sickness
-BSICK_MIN_HP = 50 #min hp to go to
+BSICK_DURATION = 60  # duration of sickness
+BSICK_DECLINE = 30  # decline time of sickness
+BSICK_INCLINE = SICK_DURATION - SICK_DECLINE  # incline time of sickness
+BSICK_MIN_HP = 50  # min hp to go to
 
 
 # db logging terms
@@ -193,6 +193,3 @@ PLAYER_HP_STR = "player_hp"
 PLAYER_IS_SICK_STR = "player_is_sick"
 PLAYER_IS_BSICK_STR = "player_is_bath_sick"
 PLAYER_HP_STATE_STR = "player_hp_state"
-
-
-

--- a/src/sickness.py
+++ b/src/sickness.py
@@ -1,7 +1,16 @@
 from random import random
 from typing import Callable
-
+from src.sprites.entities.player import Player
 from src.settings import GogglesStatus
+from src.settings import (
+    SICK_DURATION,
+    SICK_DECLINE,
+    SICK_INCLINE,
+    SICK_MIN_HP,
+    MAX_HP,
+    SICK_INTERVAL,
+)
+
 
 # Key format: (bath, goggles)
 # Value format: (rds 7-9, rds 10-12)
@@ -20,30 +29,24 @@ def _random_from_probability(prob: float):
 class SicknessManager:
     def __init__(
         self,
+        player: Player,
         get_round: Callable[[], int],
         get_round_end_timer: Callable[[], float],
         get_goggles_status: Callable[[], GogglesStatus],
         get_bath_status: Callable[[], bool],
-        is_ply_sick: Callable[[], bool],
-        send_telemetry: Callable[[str, dict], None],
-        make_player_sick: Callable[[], None],
-        make_ply_recover: Callable[[], None],
         reset_goggles_delta: Callable[[], None],
     ):
         self.get_round = get_round
         self.get_rend_timer = get_round_end_timer
         self._goggles_status = get_goggles_status
         self._bath_status = get_bath_status
-        self._is_ply_sick = is_ply_sick
-        self.send_telemetry = send_telemetry
-        self._make_ply_sick = make_player_sick
-        self._make_ply_recover = make_ply_recover
+        self.player = player
         self.reset_goggles_delta = reset_goggles_delta
         self.sickness_calc_count = 0
 
     @property
     def _sickness_likelihood(self) -> float:
-        if self.get_round() < 7 or self.get_rend_timer() < 300:
+        if self.get_round() < 7 or self.get_rend_timer() < SICK_INTERVAL:
             return 0.0
         return _SICKNESS_PROBABILITIES[(self._bath_status(), self._goggles_status())][
             self.get_round() > 9
@@ -53,18 +56,29 @@ class SicknessManager:
         return _random_from_probability(self._sickness_likelihood)
 
     def update_ply_sickness(self):
-        current_time = self.get_rend_timer()
-        if (
-            self.get_round() < 7 or current_time < 300
-        ):  # cannot get sick before round 7 or 5mins in
+        if not self.player.round_config.get("sickness", False):
             return
 
-        if (self.sickness_calc_count == 0) or (
-            current_time >= 600 and self.sickness_calc_count == 1
-        ):  # do at 5mins and 10mins
+        current_time = int(self.get_rend_timer()) # need int for modulo at bottom
+        # if (
+        #     self.get_round() < 7 or current_time < SICK_INTERVAL
+        # ):  # cannot get sick before round 7 or 5mins in
+        #     return
+
+        # at 5mins and 10mins determine whether a player is sick
+        if current_time >= SICK_INTERVAL*(self.sickness_calc_count + 1):
             self.sickness_calc_count += 1
             if self.should_make_player_sick():
-                self._make_ply_sick()
-            else:
-                self._make_ply_recover()
+                self.player.get_sick()
             self.reset_goggles_delta()
+
+        # at 9mins and 14mins make potentially sick player recover, otherwise change hp
+        if self.player.is_sick:
+            if current_time>=SICK_INTERVAL*self.sickness_calc_count+SICK_DURATION:
+                self.player.recover()
+            else: #adjust hp logic
+                sick_interval_time = current_time % SICK_INTERVAL
+                if sick_interval_time < SICK_DECLINE:  # first decrease health
+                    self.player.set_hp(MAX_HP - (MAX_HP-SICK_MIN_HP)*sick_interval_time/SICK_DECLINE)
+                else:  # then increase health again
+                    self.player.set_hp(SICK_MIN_HP + (MAX_HP-SICK_MIN_HP)*(sick_interval_time-SICK_DECLINE)/SICK_INCLINE)

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -137,7 +137,7 @@ class Player(Character):
         # sounds
         self.sounds = sounds
 
-        self.hp = 100
+        self.hp = MAX_HP
         # self.created_time = time.time() # used for speed unclear why
         # self.delay_time_speed = 0.25
         self.dt_speed = 0

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -40,6 +40,7 @@ from src.settings import (
     POS_MOVE_LOG_INTERVAL,
     Coordinate,
     SoundDict,
+    MAX_HP,
 )
 from src.sprites.entities.character import Character
 from src.sprites.entities.entity import Entity
@@ -78,7 +79,6 @@ class Player(Character):
         interact: Callable[[], None],
         emote_manager: PlayerEmoteManager,
         sounds: SoundDict,
-        hp: int,
         bath_time: float,
         save_file: SaveFile,
         round_config: dict[str, Any],
@@ -95,7 +95,7 @@ class Player(Character):
             plant_collision=plant_collision,
         )
 
-        self.is_sick = False
+        self.is_sick = True
         self.round_config = round_config
         self.get_game_version = get_game_version
         self.send_telemetry = send_telemetry
@@ -131,7 +131,7 @@ class Player(Character):
         # sounds
         self.sounds = sounds
 
-        self.hp = hp
+        self.hp = 100
         # self.created_time = time.time() # used for speed unclear why
         # self.delay_time_speed = 0.25
         self.dt_speed = 0
@@ -164,9 +164,13 @@ class Player(Character):
             {PLAYER_HP: self.hp, PLAYER_IS_SICK: self.is_sick},
         )
 
+    def set_hp(self, hp):
+        self.hp = pygame.math.clamp(hp, 0, MAX_HP)
+
+
     def recover(self):
         self.is_sick = False
-        self.hp = 100
+        self.set_hp(MAX_HP)
         self.send_telemetry(
             PLAYER_HP_STATE,
             {PLAYER_HP: self.hp, PLAYER_IS_SICK: self.is_sick},

--- a/src/sprites/entities/player.py
+++ b/src/sprites/entities/player.py
@@ -35,15 +35,15 @@ from src.savefile import SaveFile
 from src.settings import (
     DEBUG_MODE_VERSION,
     MAX_DT,
+    MAX_HP,
+    PLAYER_HP_STATE_STR,
+    PLAYER_HP_STR,
+    PLAYER_IS_BSICK_STR,
+    PLAYER_IS_SICK_STR,
     POS_MIN_LOG_INTERVAL,
     POS_MOVE_LOG_INTERVAL,
     Coordinate,
     SoundDict,
-    MAX_HP,
-    PLAYER_HP_STR,
-    PLAYER_HP_STATE_STR,
-    PLAYER_IS_SICK_STR,
-    PLAYER_IS_BSICK_STR,
 )
 from src.sprites.entities.character import Character
 from src.sprites.entities.entity import Entity
@@ -167,7 +167,11 @@ class Player(Character):
         self.emote_manager.show_emote(self, "sad_sick_ani")
         self.send_telemetry(
             PLAYER_HP_STATE_STR,
-            {PLAYER_HP_STR: self.hp, PLAYER_IS_SICK_STR: self.is_sick, PLAYER_IS_BSICK_STR: self.is_bath_sick},
+            {
+                PLAYER_HP_STR: self.hp,
+                PLAYER_IS_SICK_STR: self.is_sick,
+                PLAYER_IS_BSICK_STR: self.is_bath_sick,
+            },
         )
 
     def get_bath_sick(self, round_time):
@@ -178,12 +182,15 @@ class Player(Character):
         self.emote_manager.show_emote(self, "sad_sick_ani")
         self.send_telemetry(
             PLAYER_HP_STATE_STR,
-            {PLAYER_HP_STR: self.hp, PLAYER_IS_SICK_STR: self.is_sick, PLAYER_IS_BSICK_STR: self.is_bath_sick},
+            {
+                PLAYER_HP_STR: self.hp,
+                PLAYER_IS_SICK_STR: self.is_sick,
+                PLAYER_IS_BSICK_STR: self.is_bath_sick,
+            },
         )
 
     def set_hp(self, hp):
         self.hp = pygame.math.clamp(hp, 0, MAX_HP)
-
 
     def recover(self):
         self.is_sick = False
@@ -191,7 +198,11 @@ class Player(Character):
         self.set_hp(MAX_HP)
         self.send_telemetry(
             PLAYER_HP_STATE_STR,
-            {PLAYER_HP_STR: self.hp, PLAYER_IS_SICK_STR: self.is_sick, PLAYER_IS_BSICK_STR: self.is_bath_sick},
+            {
+                PLAYER_HP_STR: self.hp,
+                PLAYER_IS_SICK_STR: self.is_sick,
+                PLAYER_IS_BSICK_STR: self.is_bath_sick,
+            },
         )
 
     def save(self):


### PR DESCRIPTION
This is a larger merge of various updates based on direct discussions with @sloukit :

- Cleaned up sickness manager and logic in it
   - All variables / attributes are now strictly with the player object
   - All logic is in the actual manager class (as opposed to having hp logic in the health bar display)
   - The durations and intensity of sickness / bath-sickness can be configured in the settings files as opposed to having a lot of hard coded values
- A player is now only sick for 4 mins, 2mins of which the health declines, 2mins it inclines
- When a player goes to the bath, he/she is sick for 1min afterwards (with reduced intensity)
- The bath has effect whenever a player is not already sick
- If the player is sick from the bath and passes one of the possible sickness marks (5min, 10min), the determination whether he/she gets sick is done afterwards
- The npc sickness manager is completely overhauled. It still produces the same data and interacts with the DB correctly but has much less redundant data structures
    - All events are now in a flat list that is sorted in reverse, such that the next event can always be retrieved using `.pop()`
- Various smaller changes like removing unneeded leftover code
