### PR TITLE
Fix glasses blur to apply underneath menus with minimal changes, #104

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ _CAMERA_TARGET_TO_TEXT_SOLO = (
 _TARG_SKIP_IDX_SOLO = _CAMERA_TARGET_TO_TEXT_SOLO.index("outgroup_introduction_text")
 _GOGGLES_TUT_TSTAMP = 35
 _ENABLE_SICKNESS_TSTAMP = 33
-_BLUR_FACTOR = 1
+_BLUR_FACTOR = 2
 
 
 def _get_alloc_text(alloc_id: str):
@@ -1136,7 +1136,7 @@ class Game:
 
             if self.player.has_goggles:
                 self.player.goggle_time += dt
-            # this draw duplicates the same call in level.py, but without it, dialog box won't be visible
+            # this draw call handles dialogues
             self.all_sprites.draw(
                 self.level.camera,
                 is_game_paused,
@@ -1146,7 +1146,14 @@ class Game:
 
             # Apply blur effect only if the player has goggles equipped
             if self.player.has_goggles and self.current_state == GameState.PLAY:
-                surface = pygame.transform.box_blur(self.display_surface, _BLUR_FACTOR)
+                # box blur is too slow, so use smoothscale instead
+                surface = pygame.transform.smoothscale(
+                    pygame.transform.smoothscale(
+                        self.display_surface,
+                        (SCREEN_WIDTH // _BLUR_FACTOR, SCREEN_HEIGHT // _BLUR_FACTOR),
+                    ),
+                    (SCREEN_WIDTH, SCREEN_HEIGHT),
+                )
                 FBLITTER.schedule_blit(surface, (0, 0))
 
             # Into and Tutorial

--- a/main.py
+++ b/main.py
@@ -118,7 +118,6 @@ _CAMERA_TARGET_TO_TEXT_SOLO = (
 _TARG_SKIP_IDX_SOLO = _CAMERA_TARGET_TO_TEXT_SOLO.index("outgroup_introduction_text")
 _GOGGLES_TUT_TSTAMP = 35
 _ENABLE_SICKNESS_TSTAMP = 33
-_BLUR_FACTOR = 2
 
 
 def _get_alloc_text(alloc_id: str):
@@ -1140,21 +1139,11 @@ class Game:
             self.all_sprites.draw(
                 self.level.camera,
                 is_game_paused,
+                self.player.has_goggles,
+                self.current_state == GameState.PLAY
             )
 
             FBLITTER.blit_all()
-
-            # Apply blur effect only if the player has goggles equipped
-            if self.player.has_goggles and self.current_state == GameState.PLAY:
-                # box blur is too slow, so use smoothscale instead
-                surface = pygame.transform.smoothscale(
-                    pygame.transform.smoothscale(
-                        self.display_surface,
-                        (SCREEN_WIDTH // _BLUR_FACTOR, SCREEN_HEIGHT // _BLUR_FACTOR),
-                    ),
-                    (SCREEN_WIDTH, SCREEN_HEIGHT),
-                )
-                FBLITTER.schedule_blit(surface, (0, 0))
 
             # Into and Tutorial
             self.show_intro_msg()

--- a/main.py
+++ b/main.py
@@ -1140,7 +1140,7 @@ class Game:
                 self.level.camera,
                 is_game_paused,
                 self.player.has_goggles,
-                self.current_state == GameState.PLAY
+                self.current_state == GameState.PLAY,
             )
 
             FBLITTER.blit_all()

--- a/src/fblitter.py
+++ b/src/fblitter.py
@@ -55,7 +55,12 @@ class _FBlitterType:
     def blit_all(self):
         """Blits everything saved for the current surface and then resets the current surface to the default display surface.
 
-        Blits saved for the display surface are NOT performed if the current surface isn't the display surface."""
+        Blits saved for the display surface are NOT performed if the current surface isn't the display surface.
+        
+        This only happens during the first section of the menu, all other blits are normal
+
+        Called mainly by groups.py (draw extra sprite details) and main.py (draw cursor on top)
+        """
         return self._blit_all_internal() or self.reset_to_default_surf()
 
     def blit_with_special_flags(self, surf: pygame.Surface, pos: RectLike, flags: int):

--- a/src/fblitter.py
+++ b/src/fblitter.py
@@ -56,7 +56,7 @@ class _FBlitterType:
         """Blits everything saved for the current surface and then resets the current surface to the default display surface.
 
         Blits saved for the display surface are NOT performed if the current surface isn't the display surface.
-        
+
         This only happens during the first section of the menu, all other blits are normal
 
         Called mainly by groups.py (draw extra sprite details) and main.py (draw cursor on top)

--- a/src/groups.py
+++ b/src/groups.py
@@ -53,12 +53,12 @@ class AllSprites(PersistentSpriteGroup):
         for sprite in self:
             getattr(sprite, "update_blocked", sprite.update)(dt)
 
-    def draw(self, camera: Camera, game_paused: bool, has_goggles, state=True):
+    def draw(self, camera: Camera, game_paused: bool, has_goggles, is_main_draw=True):
         sorted_sprites = sorted(self, key=lambda spr: (spr.z, spr.hitbox_rect.bottom))
 
         # Apply blur effect only if the player has goggles equipped
-        # State only matters when drawn from main
-        if has_goggles and state:
+        # Blur only matters when drawn from main
+        if has_goggles and is_main_draw:
             # box blur is too slow, so use smoothscale instead
             surface = pygame.transform.smoothscale(
                 pygame.transform.smoothscale(

--- a/src/groups.py
+++ b/src/groups.py
@@ -2,7 +2,24 @@ import pygame
 
 from src.camera import Camera
 from src.fblitter import FBLITTER
-
+from src.settings import (
+    DEBUG_MODE_VERSION,
+    EMOTE_SIZE,
+    GAME_LANGUAGE,
+    GVT_TB_SIZE,
+    RANDOM_SEED,
+    SCREEN_HEIGHT,
+    SCREEN_WIDTH,
+    TB_SIZE,
+    TUTORIAL_TB_LEFT,
+    TUTORIAL_TB_TOP,
+    USE_SERVER,
+    WORLD_TIME_MULTIPLIER,
+    AniFrames,
+    MapDict,
+    SoundDict,
+)
+_BLUR_FACTOR = 4
 
 class PersistentSpriteGroup(pygame.sprite.Group):
     _persistent_sprites: list[pygame.sprite.Sprite]
@@ -47,8 +64,22 @@ class AllSprites(PersistentSpriteGroup):
         for sprite in self:
             getattr(sprite, "update_blocked", sprite.update)(dt)
 
-    def draw(self, camera: Camera, game_paused: bool):
+    def draw(self, camera: Camera, game_paused: bool, has_goggles, state=True):
         sorted_sprites = sorted(self, key=lambda spr: (spr.z, spr.hitbox_rect.bottom))
+
+        # Apply blur effect only if the player has goggles equipped
+        # State only matters when drawn from main
+        if has_goggles and state:
+            # box blur is too slow, so use smoothscale instead
+            surface = pygame.transform.smoothscale(
+                pygame.transform.smoothscale(
+                    self.display_surface,
+                    (SCREEN_WIDTH // _BLUR_FACTOR, SCREEN_HEIGHT // _BLUR_FACTOR),
+                ),
+                (SCREEN_WIDTH, SCREEN_HEIGHT),
+            )
+            self.display_surface.blit(surface, (0, 0))
+            #FBLITTER.schedule_blit(surface, (0, 0)) # breaks?
 
         camera_rect = camera.get_viewport_rect()
         for sprite in sorted_sprites:

--- a/src/groups.py
+++ b/src/groups.py
@@ -3,23 +3,12 @@ import pygame
 from src.camera import Camera
 from src.fblitter import FBLITTER
 from src.settings import (
-    DEBUG_MODE_VERSION,
-    EMOTE_SIZE,
-    GAME_LANGUAGE,
-    GVT_TB_SIZE,
-    RANDOM_SEED,
     SCREEN_HEIGHT,
     SCREEN_WIDTH,
-    TB_SIZE,
-    TUTORIAL_TB_LEFT,
-    TUTORIAL_TB_TOP,
-    USE_SERVER,
-    WORLD_TIME_MULTIPLIER,
-    AniFrames,
-    MapDict,
-    SoundDict,
 )
+
 _BLUR_FACTOR = 4
+
 
 class PersistentSpriteGroup(pygame.sprite.Group):
     _persistent_sprites: list[pygame.sprite.Sprite]
@@ -79,7 +68,7 @@ class AllSprites(PersistentSpriteGroup):
                 (SCREEN_WIDTH, SCREEN_HEIGHT),
             )
             self.display_surface.blit(surface, (0, 0))
-            #FBLITTER.schedule_blit(surface, (0, 0)) # breaks?
+            # FBLITTER.schedule_blit(surface, (0, 0)) # breaks?
 
         camera_rect = camera.get_viewport_rect()
         for sprite in sorted_sprites:

--- a/src/screens/level.py
+++ b/src/screens/level.py
@@ -1314,7 +1314,7 @@ class Level:
 
     def draw(self, dt: float, move_things: bool):
         # self.display_surface.fill((130, 168, 132))
-        self.all_sprites.draw(self.camera, False)
+        self.all_sprites.draw(self.camera, False, self.player.has_goggles)
 
         self.draw_pf_overlay()
         self.draw_hitboxes()


### PR DESCRIPTION
## Summary

This PR implements the remaining bullets points in #104 (bullet points 2-6) without complicated changes or a rewrite of the fblitter. Added some documentation for the next poor soul to come across it

Attached video shows the effect and button spamming with a blur factor of 4 (which might be too blurry!)

https://github.com/user-attachments/assets/2ce453e6-8ba4-4f85-89fe-ad2453604ae0

## Checklist

- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.
<!-- - [ ] Since this PR modifies related documentation, I have proofread files for spelling and grammar errors. -->

## Labels
gameplay-glasses
