### PR TITLE
Control options menu now auto closes on a cutscene trigger if it was open

### DIFF
--- a/main.py
+++ b/main.py
@@ -1007,6 +1007,10 @@ class Game:
 
             if not is_game_paused or is_first_frame:
                 if self.level.cutscene_animation.active:
+                    # if cutscene animation is active and box keybindings are visible, then hide them
+                    if self.level.overlay.box_keybindings.visible:
+                        self.level.overlay.box_keybindings.visible = False
+
                     event = pygame.key.get_pressed()
                     if (
                         event[pygame.K_RSHIFT]


### PR DESCRIPTION
## Summary
This PR fixes issue #111 , by making the control options menu close if it was open and a cutscene was triggered.

## Checklist
- [x] I have tested this change locally and it works as expected.
- [x] I have made sure that the code follows the formatting and style guidelines of the project.