### PR TITLE
Emotes are now fixed and working proprely.

### DIFF
--- a/src/gui/interface/emotes.py
+++ b/src/gui/interface/emotes.py
@@ -72,7 +72,7 @@ class EmoteBox(EmoteBoxBase):
     def pos(self, value: tuple[float, float]):
         self._pos = value
         self.rect.update(self._pos, self.rect.size)
-        # keep hitbox in sync so camera culling uses the correct position
+        # synchronize the hitbox to the camera - updates to the correct position [^1]
         if hasattr(self, "hitbox_rect") and self.hitbox_rect:
             self.hitbox_rect.update(self.rect.topleft, self.rect.size)
 
@@ -322,7 +322,7 @@ class EmoteWheel(EmoteWheelBase):
             (self._pos[0] - self.rect.width / 2, self._pos[1] - self.rect.height / 2),
             self.rect.size,
         )
-        # keep hitbox in sync so camera culling uses the correct position
+        # synchronize the hitbox to the camera - updates to the correct position [^1]
         if hasattr(self, "hitbox_rect") and self.hitbox_rect:
             self.hitbox_rect.update(self.rect.topleft, self.rect.size)
 
@@ -474,3 +474,12 @@ class PlayerEmoteManager(EmoteManager):
         else:
             for func in self.__on_emote_wheel_closed_funcs:
                 func()
+
+
+# Footnotes for explanations:
+# [1] - From testing, it seems that the camera would check culling colisions based on
+# "World-Space" (present in the game world instead of being fixed on screen - Not UI)
+# instead of checking the "Screen-Space" (fixed on screen - UI). This would prevent
+# the UI elements and certain layers from the rendering. By updating the hitbox
+# position, we bypass the issue and still let the culling work proprely.
+# (This is not a fix, just a workaround)

--- a/src/sprites/entities/entity.py
+++ b/src/sprites/entities/entity.py
@@ -269,7 +269,7 @@ class Entity(CollideableSprite, ABC):
                 ),
                 self.focused_indicator.rect.size,
             )
-            # keep hitbox_rect in sync so the indicator is considered by camera culling
+            # synchronize the hitbox to the camera - updates to the correct position [^1]
             if (
                 hasattr(self.focused_indicator, "hitbox_rect")
                 and self.focused_indicator.hitbox_rect
@@ -279,7 +279,7 @@ class Entity(CollideableSprite, ABC):
                     self.focused_indicator.rect.size,
                 )
             else:
-                # ensure hitbox_rect exists for compatibility
+                # forces the hitbox_rect to exist for compatibility reasons
                 self.focused_indicator.hitbox_rect = self.focused_indicator.rect.copy()
 
     def update(self, dt: float):
@@ -293,3 +293,12 @@ class Entity(CollideableSprite, ABC):
         self._do_common_update_ops()
         self.animate(dt)
         self.image = self._current_frame
+
+
+# Footnotes for explanations:
+# [1] - From testing, it seems that the camera would check culling colisions based on
+# "World-Space" (present in the game world instead of being fixed on screen - Not UI)
+# instead of checking the "Screen-Space" (fixed on screen - UI). This would prevent
+# the UI elements and certain layers from the rendering. By updating the hitbox
+# position, we bypass the issue and still let the culling work proprely.
+# (This is not a fix, just a workaround)


### PR DESCRIPTION
## Summary 

This PR fixes #126.

Turns out that the camera culling has been preventing emotes from rendering. 

## Media

<img width="1636" height="975" alt="Screenshot 2025-08-22 135807" src="https://github.com/user-attachments/assets/cd42dcfe-552f-41d5-b25b-4a8226fe25e1" />


## Checklist

- [X] I have tested this change locally and it works as expected.
- [X] I have made sure that the code follows the formatting and style guidelines of the project.